### PR TITLE
fix: Correct CI by using a virtual environment with uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,12 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install uv
       run: python -m pip install --upgrade pip uv
-    - name: Install dependencies
+    - name: Create virtual environment and install dependencies
       run: |
+        uv venv .venv
+        source .venv/bin/activate
         uv pip install -e ".[image,dev]"
     - name: Test with pytest
       run: |
+        source .venv/bin/activate
         pytest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,12 +9,16 @@ This file provides instructions for AI agents working with this codebase.
     *   All new features must be accompanied by unit tests.
     *   Ensure all tests pass before submitting changes.
     *   The command to run tests is `pytest`.
-    *   Dependencies, including test dependencies like `pytest`, are managed with `uv` and specified in `pyproject.toml`. Install them using `uv pip install -e ".[image,dev]"`.
+    *   **Environment Setup:** It is recommended to use `uv` for managing virtual environments and dependencies.
+        *   Create a virtual environment: `uv venv .venv` (or your preferred directory name).
+        *   Activate the environment: `source .venv/bin/activate` (Linux/macOS) or `.venv\\Scripts\\activate` (Windows).
+        *   Install dependencies: `uv pip install -e ".[image,dev]"` (as specified in `pyproject.toml`).
 *   **Commit Messages:** Follow conventional commit message formats.
 *   **CI/CD:** The continuous integration pipeline is managed by GitHub Actions, configured in `.github/workflows/ci.yml`.
     *   It uses Python 3.12.
+    *   It creates a virtual environment using `uv venv .venv` and activates it.
     *   It installs dependencies using `uv pip install -e ".[image,dev]"`.
-    *   It runs tests using `pytest`.
+    *   It runs tests using `pytest` (within the activated virtual environment).
     *   Any changes to the build or test process should be reflected there and in this document.
 
 ### Specific Instructions


### PR DESCRIPTION
- Modify GitHub Actions workflow (.github/workflows/ci.yml):
  - Add step to create a virtual environment using `uv venv .venv`.
  - Activate the virtual environment using `source .venv/bin/activate` before installing dependencies and running tests.
- Update AGENTS.md to reflect the use of `uv venv` for local development environment setup, aligning with CI practices.