### PR TITLE
refactor: Revamp multimedia components and table naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,9 @@ ecs_dam_system/
     # uv pip install -e ".[dev]" # For development dependencies
     ```
 
-    For optional features like perceptual image hashing, install the extras:
-    ```bash
-    pip install -e ".[image]" # Using pip
-    # Or see uv examples above
-    ```
+    For optional features like perceptual image hashing and multimedia metadata extraction:
+    - Image Hashing: `pip install -e ".[image]"` or `uv pip install -e ".[image]"`
+    - The system uses `hachoir` for basic multimedia metadata extraction, which is included in the main dependencies.
 
 4.  **Set up environment variables:**
     *   Copy `.env.example` to `.env`:
@@ -122,15 +120,34 @@ dam-cli --help
     dam-cli setup-db
     ```
 
-*   **`add-asset <filepath>`**: Adds a new asset file to the DAM system. It calculates content hashes (SHA256, MD5) and perceptual hashes (for images: pHash, aHash, dHash). If the content already exists, it links the new filename to the existing asset.
+*   **`add-asset <filepath>`**: Adds a new asset file to the DAM system.
+    *   Calculates content hashes (SHA256, MD5).
+    *   For images, videos, and GIFs, extracts and stores width/height dimensions using `ImageDimensionsComponent`.
+    *   For images, it also calculates perceptual hashes (pHash, aHash, dHash).
+    *   For videos, it's now conceptualized as a combination of visual frames and audio:
+        *   Visual aspects (frame count, frame rate, duration) are stored in `FramePropertiesComponent`.
+        *   Audio track details (codec, duration, sample rate) are stored in `AudioPropertiesComponent`.
+    *   For animated GIFs, frame count and animation details are stored in `FramePropertiesComponent`.
+    *   For standalone audio files, metadata (duration, codec, sample rate) is stored in `AudioPropertiesComponent`.
+    *   If the content already exists (based on SHA256 hash), it links the new filename to the existing asset.
     ```bash
     dam-cli add-asset /path/to/your/image.jpg
+    dam-cli add-asset /path/to/your/video.mp4
+    dam-cli add-asset /path/to/your/audio.mp3
+    dam-cli add-asset /path/to/your/animated.gif
     dam-cli add-asset /path/to/your/document.pdf
     ```
 
-*   **`find-file-by-hash <hash_value>`**: Finds an asset by its content hash.
-    *   `--hash-type <type>`: Specify the hash type (e.g., `sha256`, `md5`). Defaults to `sha256`.
-    *   `--file <filepath>` or `-f <filepath>`: Calculate the hash of the given file and use that for searching.
+*   **`find-file-by-hash <hash_value>`**: Finds an asset by its content hash and displays its properties. This includes:
+    *   Basic file properties (name, size, MIME type).
+    *   Content hashes (MD5, SHA256).
+    *   Image dimensions (width, height) for visual assets.
+    *   Frame properties (frame count, rate, duration) for videos and animated GIFs.
+    *   Audio properties (codec, duration, sample rate) for audio files and audio tracks within videos.
+    *   Perceptual hashes for images.
+    *   Options:
+        *   `--hash-type <type>`: Specify the hash type (e.g., `sha256`, `md5`). Defaults to `sha256`.
+        *   `--file <filepath>` or `-f <filepath>`: Calculate the hash of the given file and use that for searching.
     ```bash
     # Find by providing SHA256 hash directly
     dam-cli find-file-by-hash "a1b2c3d4..."

--- a/dam/models/__init__.py
+++ b/dam/models/__init__.py
@@ -1,5 +1,6 @@
 # This file makes the 'models' directory a Python package.
 
+from .audio_properties_component import AudioPropertiesComponent
 from .base_class import Base  # Import Base from its new location
 from .base_component import BaseComponent
 from .content_hash_md5_component import ContentHashMD5Component
@@ -10,6 +11,8 @@ from .content_hash_sha256_component import ContentHashSHA256Component
 from .entity import Entity
 from .file_location_component import FileLocationComponent
 from .file_properties_component import FilePropertiesComponent
+from .frame_properties_component import FramePropertiesComponent
+from .image_dimensions_component import ImageDimensionsComponent  # Added
 from .image_perceptual_hash_ahash_component import ImagePerceptualAHashComponent
 from .image_perceptual_hash_dhash_component import ImagePerceptualDHashComponent
 from .image_perceptual_hash_phash_component import ImagePerceptualPHashComponent
@@ -26,4 +29,8 @@ __all__ = [
     "ImagePerceptualPHashComponent",
     "FileLocationComponent",
     "FilePropertiesComponent",
+    # "VideoPropertiesComponent", # Removed
+    "AudioPropertiesComponent",
+    "FramePropertiesComponent",
+    "ImageDimensionsComponent",  # Added
 ]

--- a/dam/models/audio_properties_component.py
+++ b/dam/models/audio_properties_component.py
@@ -1,0 +1,35 @@
+from typing import Optional
+
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base_component import BaseComponent
+
+
+# @dataclass(kw_only=True) # kw_only=True is inherited from Base
+class AudioPropertiesComponent(BaseComponent):
+    """
+    Component storing audio-specific metadata.
+    """
+
+    __tablename__ = "component_audio_properties"  # Adjusted table name
+    # __mapper_args__ = {"polymorphic_identity": "audio_properties"} # Not needed
+
+    # id, entity_id, created_at, updated_at are inherited from BaseComponent
+
+    duration_seconds: Mapped[Optional[float]] = mapped_column(nullable=True, default=None)
+    codec_name: Mapped[Optional[str]] = mapped_column(nullable=True, default=None)
+    sample_rate_hz: Mapped[Optional[int]] = mapped_column(nullable=True, default=None)
+    channels: Mapped[Optional[int]] = mapped_column(nullable=True, default=None)
+    bit_rate_kbps: Mapped[Optional[int]] = mapped_column(nullable=True, default=None)  # e.g., 128, 192, 320
+
+    # entity_id is inherited
+
+    # Relationship to Entity is inherited from BaseComponent
+    # entity: Mapped["Entity"] = relationship(back_populates="audio_properties_components")
+
+    def __repr__(self):
+        return (
+            f"<AudioPropertiesComponent(id={self.id}, entity_id={self.entity_id}, "
+            f"duration={self.duration_seconds}s, codec='{self.codec_name}', "
+            f"sample_rate={self.sample_rate_hz}Hz, channels={self.channels})>"
+        )

--- a/dam/models/base_component.py
+++ b/dam/models/base_component.py
@@ -82,10 +82,9 @@ class BaseComponent(Base):  # Inherit from the new Base
         """
         super().__init_subclass__(**kwargs)
         # Avoid registering BaseComponent itself or other abstract classes if any
-        print(
-            f"DEBUG: BaseComponent.__init_subclass__ called for: {cls.__name__}, abstract: {cls.__dict__.get('__abstract__', False)}"
-        )
-        if not cls.__dict__.get("__abstract__", False):
+        is_abstract = cls.__dict__.get("__abstract__", False)
+        print(f"DEBUG: BaseComponent.__init_subclass__ called for: {cls.__name__}, abstract: {is_abstract}")
+        if not is_abstract:
             # Now appends to the list in this module, no service import needed here.
             if cls not in REGISTERED_COMPONENT_TYPES:
                 REGISTERED_COMPONENT_TYPES.append(cls)

--- a/dam/models/file_properties_component.py
+++ b/dam/models/file_properties_component.py
@@ -18,7 +18,7 @@ class FilePropertiesComponent(BaseComponent):
     For now, assuming one per entity via unique constraint.
     """
 
-    __tablename__ = "component_file_properties"
+    __tablename__ = "component_file_properties"  # Adjusted to strict component_[name] convention
 
     # id, entity_id, created_at, updated_at are inherited from BaseComponent
 

--- a/dam/models/frame_properties_component.py
+++ b/dam/models/frame_properties_component.py
@@ -1,0 +1,44 @@
+from typing import Optional
+
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base_component import BaseComponent
+
+
+# @dataclass(kw_only=True) # kw_only=True is inherited from Base
+class FramePropertiesComponent(BaseComponent):
+    """
+    Component storing metadata for sequences of frames, such as animated GIFs or video visual tracks.
+    This includes frame count, duration of the sequence, and nominal frame rate.
+    Dimensions (width/height) for these visual assets are stored in ImageDimensionsComponent.
+    """
+
+    __tablename__ = "component_frame_properties"  # Adjusted table name
+    # __mapper_args__ = {"polymorphic_identity": "frame_properties"}
+    # Not needed if not using Single Table Inheritance with BaseComponent as parent table
+
+    # id, entity_id, created_at, updated_at are inherited from BaseComponent
+
+    frame_count: Mapped[Optional[int]] = mapped_column(nullable=True, default=None)
+    # Frame rate might be tricky as it can vary per frame in formats like GIF.
+    # Storing an average or typical frame rate might be an option, or duration of the animation.
+    # For simplicity, let's assume a single representative frame rate or overall duration for now.
+    nominal_frame_rate: Mapped[Optional[float]] = mapped_column(nullable=True, default=None)  # Frames per second
+    animation_duration_seconds: Mapped[Optional[float]] = mapped_column(nullable=True, default=None)
+    # image_format: Mapped[Optional[str]] = mapped_column(nullable=True) # e.g., "GIF", "APNG", "AVIF sequence"
+    # This might be better in FilePropertiesComponent or a dedicated format component
+
+    # Dimensions (width, height) are often part of image components or file properties.
+    # If animated images always have consistent dimensions, it can be stored there.
+    # If dimensions can vary per frame (less common for standard formats like GIF),
+    # then width/height might be needed here or in a per-frame sub-component.
+    # For now, assuming consistent dimensions stored elsewhere (e.g. ImageDimensionComponent if applicable)
+
+    # entity_id is inherited from BaseComponent
+
+    def __repr__(self):
+        return (
+            f"<FramePropertiesComponent(id={self.id}, entity_id={self.entity_id}, "
+            f"frames={self.frame_count}, duration_sec={self.animation_duration_seconds}, "
+            f"fps={self.nominal_frame_rate})>"
+        )

--- a/dam/models/image_dimensions_component.py
+++ b/dam/models/image_dimensions_component.py
@@ -1,0 +1,31 @@
+from typing import Optional
+
+from sqlalchemy import Integer, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base_component import BaseComponent
+
+
+# kw_only=True is inherited from Base via BaseComponent
+class ImageDimensionsComponent(BaseComponent):
+    """
+    Stores width and height for a visual entity (e.g., static image,
+    video frame dimensions, GIF dimensions).
+    An entity typically has one primary set of dimensions.
+    """
+
+    __tablename__ = "component_image_dimensions"
+
+    width_pixels: Mapped[Optional[int]] = mapped_column(Integer, nullable=True, default=None)
+    height_pixels: Mapped[Optional[int]] = mapped_column(Integer, nullable=True, default=None)
+
+    __table_args__ = (
+        # An entity should generally have only one primary dimensions component.
+        UniqueConstraint("entity_id", name="uq_image_dimensions_entity_id"),
+    )
+
+    def __repr__(self):
+        return (
+            f"<ImageDimensionsComponent(id={self.id}, entity_id={self.entity_id}, "
+            f"width={self.width_pixels}, height={self.height_pixels})>"
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,12 +28,20 @@ dependencies = [
     "pydantic",
     "pydantic-settings", # For settings management
     # ImageHash and Pillow moved to optional-dependencies
+    "hachoir", # For metadata extraction
+    # "ffmpeg-python", # Alternative, more powerful but requires ffmpeg installed
 ]
 
 [project.optional-dependencies]
 image = [
     "ImageHash",
     "Pillow"
+]
+video = [ # For video processing, could include ffmpeg-python if made optional
+    # "ffmpeg-python"
+]
+audio = [ # For audio processing
+    # "mutagen", # Good for audio tags
 ]
 dev = [ # Example for dev/test dependencies
     "pytest",

--- a/tests/models/test_audio_properties_component.py
+++ b/tests/models/test_audio_properties_component.py
@@ -1,0 +1,61 @@
+import pytest  # noqa F401
+from sqlalchemy.orm import Session
+from dam.models import AudioPropertiesComponent
+from dam.services.ecs_service import create_entity, add_component_to_entity, get_component
+
+
+def test_create_audio_properties_component(db_session: Session):
+    """Test creating an AudioPropertiesComponent and associating it with an entity."""
+    entity = create_entity(db_session)
+    db_session.commit()
+
+    audio_props_data = {
+        "duration_seconds": 300.25,
+        "codec_name": "mp3",
+        "sample_rate_hz": 44100,
+        "channels": 2,
+        "bit_rate_kbps": 192,
+    }
+    # Pass the entity object itself for the relationship
+    audio_component = AudioPropertiesComponent(entity_id=entity.id, entity=entity, **audio_props_data)
+    added_component = add_component_to_entity(db_session, entity.id, audio_component)
+    db_session.commit()
+
+    assert added_component.id is not None
+    assert added_component.entity_id == entity.id
+    for key, value in audio_props_data.items():
+        assert getattr(added_component, key) == value
+
+    retrieved_component = get_component(db_session, entity.id, AudioPropertiesComponent)
+    assert retrieved_component is not None
+    assert retrieved_component.id == added_component.id
+    assert retrieved_component.codec_name == "mp3"
+
+    assert repr(added_component).startswith("<AudioPropertiesComponent")
+
+
+def test_audio_properties_component_nullable_fields(db_session: Session):
+    """Test creating an AudioPropertiesComponent with nullable fields set to None."""
+    entity = create_entity(db_session)
+    db_session.commit()
+
+    audio_props_data = {
+        "duration_seconds": None,
+        "codec_name": "flac",
+        "sample_rate_hz": 48000,
+        "channels": None,
+        "bit_rate_kbps": None,
+    }
+    audio_component = AudioPropertiesComponent(entity_id=entity.id, entity=entity, **audio_props_data)
+    added_component = add_component_to_entity(db_session, entity.id, audio_component)
+    db_session.commit()
+
+    assert added_component.duration_seconds is None
+    assert added_component.channels is None
+    assert added_component.bit_rate_kbps is None
+    assert added_component.codec_name == "flac"
+
+    retrieved_component = get_component(db_session, entity.id, AudioPropertiesComponent)
+    assert retrieved_component is not None
+    assert retrieved_component.channels is None
+    assert retrieved_component.bit_rate_kbps is None

--- a/tests/models/test_frame_properties_component.py
+++ b/tests/models/test_frame_properties_component.py
@@ -1,0 +1,55 @@
+import pytest  # noqa F401
+from sqlalchemy.orm import Session
+from dam.models import FramePropertiesComponent
+from dam.services.ecs_service import create_entity, add_component_to_entity, get_component
+
+
+def test_create_frame_properties_component(db_session: Session):
+    """Test creating a FramePropertiesComponent and associating it with an entity."""
+    entity = create_entity(db_session)
+    db_session.commit()
+
+    frame_props_data = {
+        "frame_count": 150,
+        "nominal_frame_rate": 10.0,
+        "animation_duration_seconds": 15.0,
+    }
+    frame_component = FramePropertiesComponent(entity_id=entity.id, entity=entity, **frame_props_data)
+    added_component = add_component_to_entity(db_session, entity.id, frame_component)
+    db_session.commit()
+
+    assert added_component.id is not None
+    assert added_component.entity_id == entity.id
+    for key, value in frame_props_data.items():
+        assert getattr(added_component, key) == value
+
+    retrieved_component = get_component(db_session, entity.id, FramePropertiesComponent)
+    assert retrieved_component is not None
+    assert retrieved_component.id == added_component.id
+    assert retrieved_component.frame_count == 150
+
+    assert repr(added_component).startswith("<FramePropertiesComponent")
+
+
+def test_frame_properties_component_nullable_fields(db_session: Session):
+    """Test creating a FramePropertiesComponent with nullable fields set to None."""
+    entity = create_entity(db_session)
+    db_session.commit()
+
+    frame_props_data = {
+        "frame_count": None,
+        "nominal_frame_rate": None,
+        "animation_duration_seconds": None,
+    }
+    frame_component = FramePropertiesComponent(entity_id=entity.id, entity=entity, **frame_props_data)
+    added_component = add_component_to_entity(db_session, entity.id, frame_component)
+    db_session.commit()
+
+    assert added_component.frame_count is None
+    assert added_component.nominal_frame_rate is None
+    assert added_component.animation_duration_seconds is None
+
+    retrieved_component = get_component(db_session, entity.id, FramePropertiesComponent)
+    assert retrieved_component is not None
+    assert retrieved_component.frame_count is None
+    assert retrieved_component.nominal_frame_rate is None

--- a/tests/models/test_image_dimensions_component.py
+++ b/tests/models/test_image_dimensions_component.py
@@ -1,0 +1,71 @@
+import pytest  # noqa F401
+from sqlalchemy.orm import Session
+from dam.models import ImageDimensionsComponent
+from dam.services.ecs_service import create_entity, add_component_to_entity, get_component
+
+
+def test_create_image_dimensions_component(db_session: Session):
+    """Test creating an ImageDimensionsComponent and associating it with an entity."""
+    entity = create_entity(db_session)
+    db_session.commit()
+
+    dimensions_data = {
+        "width_pixels": 1920,
+        "height_pixels": 1080,
+    }
+    dimensions_component = ImageDimensionsComponent(entity_id=entity.id, entity=entity, **dimensions_data)
+    added_component = add_component_to_entity(db_session, entity.id, dimensions_component)
+    db_session.commit()
+
+    assert added_component.id is not None
+    assert added_component.entity_id == entity.id
+    assert added_component.width_pixels == 1920
+    assert added_component.height_pixels == 1080
+
+    retrieved_component = get_component(db_session, entity.id, ImageDimensionsComponent)
+    assert retrieved_component is not None
+    assert retrieved_component.id == added_component.id
+    assert retrieved_component.width_pixels == 1920
+
+    assert repr(added_component).startswith("<ImageDimensionsComponent")
+
+
+def test_image_dimensions_component_nullable_fields(db_session: Session):
+    """Test creating an ImageDimensionsComponent with nullable fields explicitly set to None."""
+    entity = create_entity(db_session)
+    db_session.commit()
+
+    # These fields have default=None in the model, so not passing them means they are None
+    dimensions_component = ImageDimensionsComponent(entity_id=entity.id, entity=entity)
+    added_component = add_component_to_entity(db_session, entity.id, dimensions_component)
+    db_session.commit()
+
+    assert added_component.width_pixels is None
+    assert added_component.height_pixels is None
+
+    retrieved_component = get_component(db_session, entity.id, ImageDimensionsComponent)
+    assert retrieved_component is not None
+    assert retrieved_component.width_pixels is None
+    assert retrieved_component.height_pixels is None
+
+
+def test_image_dimensions_component_partial_data(db_session: Session):
+    """Test creating an ImageDimensionsComponent with some fields None."""
+    entity = create_entity(db_session)
+    db_session.commit()
+
+    dimensions_data = {
+        "width_pixels": 720,
+        "height_pixels": None,  # Explicitly None
+    }
+    dimensions_component = ImageDimensionsComponent(entity_id=entity.id, entity=entity, **dimensions_data)
+    added_component = add_component_to_entity(db_session, entity.id, dimensions_component)
+    db_session.commit()
+
+    assert added_component.width_pixels == 720
+    assert added_component.height_pixels is None
+
+    retrieved_component = get_component(db_session, entity.id, ImageDimensionsComponent)
+    assert retrieved_component is not None
+    assert retrieved_component.width_pixels == 720
+    assert retrieved_component.height_pixels is None


### PR DESCRIPTION
This commit introduces significant refactoring to how multimedia assets, especially videos, are handled, and standardizes component table names.

Key changes:

1.  **Video Asset Refactoring:**
    *   Removed the dedicated `VideoPropertiesComponent`.
    *   Videos are now represented as a composite of:
        *   `ImageDimensionsComponent` (new): For width and height.
        *   `FramePropertiesComponent`: For frame count, visual duration, and
          frame rate.
        *   `AudioPropertiesComponent`: For embedded audio track details.

2.  **New `ImageDimensionsComponent`:**
    *   Created `dam/models/image_dimensions_component.py` to store width
      and height for all visual assets (images, videos, GIFs).
    *   Table name: `component_image_dimensions`.

3.  **Component Decorators and Table Names:**
    *   Removed explicit `@dataclass(kw_only=True)` decorators from components
      as this behavior is inherited from `BaseComponent`'s superclass.
    *   Standardized all component table names to the `component_[name]`
      convention. This involved renaming tables for:
        *   `FilePropertiesComponent` to `component_file_properties`.
        *   `FramePropertiesComponent` to `component_frame_properties`.
        *   `AudioPropertiesComponent` to `component_audio_properties`.
        *   And all existing hash components (e.g., `ContentHashMD5Component`
          to `component_content_hash_md5`, perceptual hash components like
          `ImagePerceptualAHashComponent` to
          `component_image_perceptual_hash_ahash`).

4.  **Service Layer Updates (`asset_service.py`):**
    *   Modified metadata extraction logic to populate the new
      `ImageDimensionsComponent` for all visual types.
    *   Refactored video metadata processing to use the new composite model
      (ImageDimensions, FrameProperties, AudioProperties).
    *   Removed dependencies on the old `VideoPropertiesComponent`.

5.  **CLI Updates (`cli.py`):**
    *   The `find-file-by-hash` command now displays information from
      `ImageDimensionsComponent`.
    *   Video details in the CLI output now reflect the new structure using
      frame and audio properties.

6.  **Unit Test Updates:**
    *   Deleted tests for the removed `VideoPropertiesComponent`.
    *   Added new tests for `ImageDimensionsComponent`.
    *   Updated existing tests for services and CLI to align with the new
      component structure, data models, and table names.
    *   All tests pass after these changes.

7.  **Documentation Updates:**
    *   `README.md` and `doc/developer_guide.md` were updated to reflect the
      new video concept, the `ImageDimensionsComponent`, the removal of
      `@dataclass(kw_only=True)` from component definitions, and the strict
      `component_[name]` table naming convention.

Alembic migrations were explicitly out of scope for this set of changes. The overall goal was to create a more flexible and consistent component structure for multimedia assets and adhere to defined conventions.