### PR TITLE
Fix test suite errors and configuration handling

### DIFF
--- a/dam/services/asset_service.py
+++ b/dam/services/asset_service.py
@@ -120,9 +120,17 @@ def add_asset_file(
         logger.exception(f"Error reading file {filepath_on_disk}")
         raise
 
-    # Store the file using the new service, passing world_name
+    from dam.core.config import settings as app_settings # Import settings
+
+    name_for_lookup = world_name
+    if name_for_lookup is None:
+        name_for_lookup = app_settings.DEFAULT_WORLD_NAME
+
+    world_config_obj = app_settings.get_world_config(name_for_lookup)
+
+    # Store the file using the new service, passing the WorldConfig object
     file_identifier = file_storage.store_file(
-        file_content, world_name=world_name, original_filename=original_filename
+        file_content, world_config=world_config_obj, original_filename=original_filename
     )
     # The file_identifier is the SHA256 content hash
 

--- a/tests/services/test_file_storage.py
+++ b/tests/services/test_file_storage.py
@@ -15,39 +15,36 @@ from dam.core.config import settings as app_settings
 
 def test_get_storage_path_for_world_valid_hash(settings_override):
     """Tests the internal _get_storage_path_for_world function with a valid hash."""
-    # settings_override has configured test worlds. Use the default one.
-    default_test_world = app_settings.DEFAULT_WORLD_NAME
-    world_config = app_settings.get_world_config(default_test_world)
+    default_test_world_name = settings_override.DEFAULT_WORLD_NAME
+    world_config_obj = settings_override.get_world_config(default_test_world_name)
 
-    current_asset_storage_path = Path(world_config.ASSET_STORAGE_PATH)
+    current_asset_storage_path = Path(world_config_obj.ASSET_STORAGE_PATH)
     test_hash = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
     expected_path = current_asset_storage_path / "ab" / "cd" / test_hash
-    # _get_storage_path_for_world requires the world_config
-    assert file_storage._get_storage_path_for_world(test_hash, world_config) == expected_path
+    assert file_storage._get_storage_path_for_world(test_hash, world_config_obj) == expected_path
 
 
 def test_get_storage_path_for_world_short_hash_raises_value_error(settings_override):
     """Tests that _get_storage_path_for_world raises ValueError for short hashes."""
-    default_test_world = app_settings.DEFAULT_WORLD_NAME
-    world_config = app_settings.get_world_config(default_test_world)
+    default_test_world_name = settings_override.DEFAULT_WORLD_NAME
+    world_config_obj = settings_override.get_world_config(default_test_world_name)
     with pytest.raises(ValueError):
-        file_storage._get_storage_path_for_world("abc", world_config)
+        file_storage._get_storage_path_for_world("abc", world_config_obj)
 
 
 def test_store_file_creates_file_and_returns_hash(settings_override):
     """Tests storing a new file in the default test world."""
-    default_test_world = app_settings.DEFAULT_WORLD_NAME
-    world_config = app_settings.get_world_config(default_test_world)
+    default_test_world_name = settings_override.DEFAULT_WORLD_NAME
+    world_config_obj = settings_override.get_world_config(default_test_world_name)
 
     file_content = b"This is a test file."
     original_filename = "test.txt"
     expected_hash = hashlib.sha256(file_content).hexdigest()
 
-    # Pass world_name to store_file
-    returned_hash = file_storage.store_file(file_content, world_name=default_test_world, original_filename=original_filename)
+    returned_hash = file_storage.store_file(file_content, world_config=world_config_obj, original_filename=original_filename)
     assert returned_hash == expected_hash
 
-    expected_path = file_storage._get_storage_path_for_world(expected_hash, world_config)
+    expected_path = file_storage._get_storage_path_for_world(expected_hash, world_config_obj)
     assert expected_path.exists()
     assert expected_path.is_file()
     with open(expected_path, "rb") as f:
@@ -56,17 +53,17 @@ def test_store_file_creates_file_and_returns_hash(settings_override):
 
 def test_store_file_empty_content(settings_override):
     """Tests storing a file with empty content in the default test world."""
-    default_test_world = app_settings.DEFAULT_WORLD_NAME
-    world_config = app_settings.get_world_config(default_test_world)
+    default_test_world_name = settings_override.DEFAULT_WORLD_NAME
+    world_config_obj = settings_override.get_world_config(default_test_world_name)
 
     file_content = b""
     original_filename = "empty.txt"
     expected_hash = hashlib.sha256(file_content).hexdigest()
 
-    returned_hash = file_storage.store_file(file_content, world_name=default_test_world, original_filename=original_filename)
+    returned_hash = file_storage.store_file(file_content, world_config=world_config_obj, original_filename=original_filename)
     assert returned_hash == expected_hash
 
-    expected_path = file_storage._get_storage_path_for_world(expected_hash, world_config)
+    expected_path = file_storage._get_storage_path_for_world(expected_hash, world_config_obj)
     assert expected_path.exists()
     with open(expected_path, "rb") as f:
         assert f.read() == file_content
@@ -74,22 +71,22 @@ def test_store_file_empty_content(settings_override):
 
 def test_store_file_duplicate_content(settings_override):
     """Tests storing duplicate content in the default test world."""
-    default_test_world = app_settings.DEFAULT_WORLD_NAME
-    world_config = app_settings.get_world_config(default_test_world)
+    default_test_world_name = settings_override.DEFAULT_WORLD_NAME
+    world_config_obj = settings_override.get_world_config(default_test_world_name)
 
     file_content = b"Duplicate content."
     original_filename1 = "dup1.txt"
     original_filename2 = "dup2.txt"
     expected_hash = hashlib.sha256(file_content).hexdigest()
 
-    hash1 = file_storage.store_file(file_content, world_name=default_test_world, original_filename=original_filename1)
+    hash1 = file_storage.store_file(file_content, world_config=world_config_obj, original_filename=original_filename1)
     assert hash1 == expected_hash
-    path1 = file_storage._get_storage_path_for_world(hash1, world_config)
+    path1 = file_storage._get_storage_path_for_world(hash1, world_config_obj)
     assert path1.exists()
 
-    hash2 = file_storage.store_file(file_content, world_name=default_test_world, original_filename=original_filename2)
+    hash2 = file_storage.store_file(file_content, world_config=world_config_obj, original_filename=original_filename2)
     assert hash2 == expected_hash
-    path2 = file_storage._get_storage_path_for_world(hash2, world_config)
+    path2 = file_storage._get_storage_path_for_world(hash2, world_config_obj)
     assert path2 == path1
 
     with open(path1, "rb") as f:
@@ -98,14 +95,14 @@ def test_store_file_duplicate_content(settings_override):
 
 def test_get_file_path_existing_file(settings_override):
     """Tests retrieving path for existing file in default test world."""
-    default_test_world = app_settings.DEFAULT_WORLD_NAME
-    world_config = app_settings.get_world_config(default_test_world)
+    default_test_world_name = settings_override.DEFAULT_WORLD_NAME
+    world_config_obj = settings_override.get_world_config(default_test_world_name)
 
     file_content = b"Find me."
-    file_hash = file_storage.store_file(file_content, world_name=default_test_world, original_filename="find_me.txt")
+    file_hash = file_storage.store_file(file_content, world_config=world_config_obj, original_filename="find_me.txt")
 
-    retrieved_path = file_storage.get_file_path(file_hash, world_name=default_test_world)
-    expected_path = file_storage._get_storage_path_for_world(file_hash, world_config).resolve()
+    retrieved_path = file_storage.get_file_path(file_hash, world_config=world_config_obj)
+    expected_path = file_storage._get_storage_path_for_world(file_hash, world_config_obj).resolve()
 
     assert retrieved_path is not None
     assert retrieved_path == expected_path
@@ -114,36 +111,38 @@ def test_get_file_path_existing_file(settings_override):
 
 def test_get_file_path_non_existing_file(settings_override):
     """Tests retrieving path for non-existing file in default test world."""
-    default_test_world = app_settings.DEFAULT_WORLD_NAME
+    default_test_world_name = settings_override.DEFAULT_WORLD_NAME
+    world_config_obj = settings_override.get_world_config(default_test_world_name) # Get world_config
     non_existent_hash = "0000000000000000000000000000000000000000000000000000000000000000"
-    retrieved_path = file_storage.get_file_path(non_existent_hash, world_name=default_test_world)
+    retrieved_path = file_storage.get_file_path(non_existent_hash, world_config=world_config_obj) # Pass world_config
     assert retrieved_path is None
 
 
 def test_get_file_path_invalid_identifier(settings_override):
     """Tests get_file_path with invalid identifier in default test world."""
-    default_test_world = app_settings.DEFAULT_WORLD_NAME
-    assert file_storage.get_file_path("short", world_name=default_test_world) is None
-    assert file_storage.get_file_path("", world_name=default_test_world) is None
+    default_test_world_name = settings_override.DEFAULT_WORLD_NAME
+    world_config_obj = settings_override.get_world_config(default_test_world_name) # Get world_config
+    assert file_storage.get_file_path("short", world_config=world_config_obj) is None # Pass world_config
+    assert file_storage.get_file_path("", world_config=world_config_obj) is None # Pass world_config
 
 
 def test_delete_file_existing(settings_override):
     """Tests deleting an existing file from default test world."""
-    default_test_world = app_settings.DEFAULT_WORLD_NAME
-    world_config = app_settings.get_world_config(default_test_world)
+    default_test_world_name = settings_override.DEFAULT_WORLD_NAME
+    world_config_obj = settings_override.get_world_config(default_test_world_name)
 
     file_content = b"To be deleted."
-    file_hash = file_storage.store_file(file_content, world_name=default_test_world, original_filename="delete_me.txt")
-    file_path = file_storage.get_file_path(file_hash, world_name=default_test_world) # Path before deletion
+    file_hash = file_storage.store_file(file_content, world_config=world_config_obj, original_filename="delete_me.txt")
+    file_path = file_storage.get_file_path(file_hash, world_config=world_config_obj) # Path before deletion
     assert file_path is not None and file_path.exists()
 
     parent_dir = file_path.parent
     grandparent_dir = parent_dir.parent
     assert parent_dir.exists() and grandparent_dir.exists()
 
-    delete_result = file_storage.delete_file(file_hash, world_name=default_test_world)
+    delete_result = file_storage.delete_file(file_hash, world_config=world_config_obj)
     assert delete_result is True
-    assert file_storage.get_file_path(file_hash, world_name=default_test_world) is None # Check it's gone
+    assert file_storage.get_file_path(file_hash, world_config=world_config_obj) is None # Check it's gone
     assert not file_path.exists() # Original path should not exist
 
     assert not parent_dir.exists() # Empty parent dirs should be removed
@@ -152,23 +151,24 @@ def test_delete_file_existing(settings_override):
 
 def test_delete_file_non_existing(settings_override):
     """Tests deleting a non-existing file from default test world."""
-    default_test_world = app_settings.DEFAULT_WORLD_NAME
+    default_test_world_name = settings_override.DEFAULT_WORLD_NAME
+    world_config_obj = settings_override.get_world_config(default_test_world_name) # Get world_config
     non_existent_hash = "1111111111111111111111111111111111111111111111111111111111111111"
-    delete_result = file_storage.delete_file(non_existent_hash, world_name=default_test_world)
+    delete_result = file_storage.delete_file(non_existent_hash, world_config=world_config_obj) # Pass world_config
     assert delete_result is False
 
 
 def test_delete_file_leaves_non_empty_directories(settings_override):
     """Tests deleting a file doesn't remove parent dirs if not empty (default test world)."""
-    default_test_world = app_settings.DEFAULT_WORLD_NAME
-    world_config = app_settings.get_world_config(default_test_world)
+    default_test_world_name = settings_override.DEFAULT_WORLD_NAME
+    world_config_obj = settings_override.get_world_config(default_test_world_name)
 
     content1 = b"File 1 in shared dir"
-    file_hash1 = file_storage.store_file(content1, world_name=default_test_world, original_filename="file1.txt")
+    file_hash1 = file_storage.store_file(content1, world_config=world_config_obj, original_filename="file1.txt")
 
     # Construct path where file1's sub-sub-directory would be
     # This relies on _get_storage_path_for_world to be correct
-    path_for_hash1_dir = file_storage._get_storage_path_for_world(file_hash1, world_config).parent
+    path_for_hash1_dir = file_storage._get_storage_path_for_world(file_hash1, world_config_obj).parent
 
     # Create a dummy file in the same directory to make it non-empty after file1 deletion
     dummy_file_in_subdir = path_for_hash1_dir / "dummy.txt"


### PR DESCRIPTION
- Refactored tests in `test_asset_service.py` to use `settings_override` fixture for world configuration, resolving issues with stale settings.
- Corrected `asset_service.add_asset_file` to use `world_config` object when calling `file_storage.store_file`.
- Updated `dam.core.config.get_world_config` for clearer error reporting.
- Fixed assertion in `test_add_gif_asset_creates_frame_and_image_props` to match actual GIF dimensions from fixture.
- Addressed `test_generate_perceptual_hashes_non_image_file` failure by noting that optional `image` dependencies (Pillow, ImageHash) are needed for the test to pass as expected. These were installed manually during the session to confirm.
- Began refactoring tests in `test_file_storage.py` to correctly use `settings_override` and pass `world_config` objects to service functions. Applied fixes to multiple tests including those for `_get_storage_path_for_world`, `store_file`, `get_file_path`, and `delete_file`.

Further work is needed in `test_file_storage.py` to apply the same pattern to remaining tests. The `pyproject.toml` should also be updated to include image dependencies in the `dev` extras to ensure a consistent test environment.