### PR TITLE
WIP: Refactor asset service to event-driven system and update tests

### DIFF
--- a/dam/core/events.py
+++ b/dam/core/events.py
@@ -1,0 +1,71 @@
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional, Any
+
+# Using dataclasses for simplicity, similar to Bevy events.
+
+@dataclass
+class BaseEvent:
+    """Base class for all events, providing a common structure if needed."""
+    pass
+
+@dataclass
+class AssetFileIngestionRequested(BaseEvent):
+    """
+    Event dispatched when a new asset file needs to be ingested by copying.
+    Corresponds to the logic previously in asset_service.add_asset_file.
+    """
+    filepath_on_disk: Path
+    original_filename: str
+    mime_type: str
+    size_bytes: int
+    world_name: str  # Target world for this asset
+
+    # To store the result of the operation for the dispatcher or caller to potentially access
+    # This is optional and depends on how we want to get results back from event handlers.
+    # For now, systems might update the DB and log, direct return might not be needed from the event itself.
+    # entity_id: Optional[int] = field(default=None, init=False)
+    # created_new: Optional[bool] = field(default=None, init=False)
+
+@dataclass
+class AssetReferenceIngestionRequested(BaseEvent):
+    """
+    Event dispatched when a new asset needs to be ingested by reference.
+    Corresponds to the logic previously in asset_service.add_asset_reference.
+    """
+    filepath_on_disk: Path
+    original_filename: str
+    mime_type: str
+    size_bytes: int
+    world_name: str  # Target world for this asset
+
+    # entity_id: Optional[int] = field(default=None, init=False)
+    # created_new: Optional[bool] = field(default=None, init=False)
+
+# Example of a potential event that could be dispatched *by* an ingestion system
+# after an asset is successfully processed, if other systems need to react to that.
+# For now, the `NeedsMetadataExtractionComponent` marker serves a similar purpose.
+# @dataclass
+# class AssetIngested(BaseEvent):
+#     entity_id: int
+#     world_name: str
+#     ingestion_type: str # e.g., "file_copy", "reference"
+#     original_filename: str
+
+# Placeholder for a system to return results if needed.
+# For now, systems will modify the DB directly.
+# If direct feedback to the caller of event dispatch is needed, a different pattern might be used.
+# For example, the dispatch method could return a future or a result object.
+# For Bevy-like events, typically events are fire-and-forget, and systems react.
+# Results are observed through changes in World state (Components, Resources).
+
+# We might also need an event to trigger the metadata extraction stage,
+# or the current mechanism of adding a marker component is sufficient.
+# Let's stick to marker components for now as it's already in place.
+
+# To allow __init__.py in dam/core to import these
+__all__ = [
+    "BaseEvent",
+    "AssetFileIngestionRequested",
+    "AssetReferenceIngestionRequested",
+]

--- a/dam/systems/__init__.py
+++ b/dam/systems/__init__.py
@@ -1,13 +1,27 @@
 # This file makes the 'dam.systems' package.
-# Import all system modules here to ensure their @system decorators run and register the systems.
+# We use importlib to ensure all system modules are loaded,
+# so their @system and @listens_for decorators run and register the systems.
 
-# from . import metadata_systems # No longer needed here if cli.py imports specific system modules
+import importlib
+import logging # Use logging for consistency
 
-# from . import hashing_systems # Example for future
-# from . import query_systems   # Example for future
-# from . import analysis_systems # Example for future
+logger = logging.getLogger(__name__)
 
-# Optionally, provide a way to list or access registered systems if needed directly,
-# though usually the WorldScheduler would handle that internally.
-# For now, simply importing is enough for registration via decorators.
-print("dam.systems package initialized, systems (like metadata_systems) should be registered.")
+# List of system modules within this package to load
+# Ensure these files exist: e.g., asset_ingestion_systems.py, metadata_systems.py
+_system_module_names = [
+    ".asset_ingestion_systems",
+    ".metadata_systems",
+]
+
+for module_name in _system_module_names:
+    try:
+        importlib.import_module(module_name, package=__name__)
+        logger.debug(f"Successfully imported system module: {module_name} from package {__name__}")
+    except ImportError as e:
+        # This error is critical if a system module is expected but not found or fails to import.
+        logger.error(f"Failed to import system module {module_name} from package {__name__}: {e}", exc_info=True)
+        # Depending on strictness, might want to re-raise or handle gracefully.
+        # For now, logging the error. If a crucial system fails to load, tests or app will likely fail later.
+
+logger.info(f"dam.systems package initialized. System modules loaded: {_system_module_names}")

--- a/dam/systems/asset_ingestion_systems.py
+++ b/dam/systems/asset_ingestion_systems.py
@@ -1,0 +1,272 @@
+import logging
+from pathlib import Path
+from typing import Tuple, Optional, Any # Ensure Any and Optional are imported
+
+from sqlalchemy.orm import Session
+from dam.core.events import AssetFileIngestionRequested, AssetReferenceIngestionRequested
+from dam.core.systems import listens_for
+# from dam.core.system_params import WorldContext # Not directly used, session, world_name, config are explicit
+from dam.models import Entity
+from dam.models.content_hash_md5_component import ContentHashMD5Component
+from dam.models.content_hash_sha256_component import ContentHashSHA256Component
+from dam.models.file_location_component import FileLocationComponent
+from dam.models.file_properties_component import FilePropertiesComponent
+from dam.models.image_perceptual_hash_ahash_component import ImagePerceptualAHashComponent
+from dam.models.image_perceptual_hash_dhash_component import ImagePerceptualDHashComponent
+from dam.models.image_perceptual_hash_phash_component import ImagePerceptualPHashComponent
+from dam.models.original_source_info_component import OriginalSourceInfoComponent
+from dam.core.components_markers import NeedsMetadataExtractionComponent
+
+from dam.services import file_storage, ecs_service
+from dam.services.file_operations import calculate_md5, calculate_sha256, generate_perceptual_hashes
+from dam.core import config as app_config # For world config access
+from dam.core.config import WorldConfig # For type hinting world_config
+
+logger = logging.getLogger(__name__)
+
+# Helper function, adapted from asset_service.find_entity_by_content_hash
+def _find_entity_by_content_hash(session: Session, hash_value: str, hash_type: str = "sha256") -> Optional[Entity]:
+    normalized_hash_type = hash_type.lower()
+    # Assuming ecs_service.select is available or we use sqlalchemy.select directly
+    from sqlalchemy import select as sql_select
+
+    if normalized_hash_type == "sha256":
+        stmt = (
+            sql_select(Entity)
+            .join(ContentHashSHA256Component, Entity.id == ContentHashSHA256Component.entity_id)
+            .where(ContentHashSHA256Component.hash_value == hash_value)
+        )
+    elif normalized_hash_type == "md5":
+        stmt = (
+            sql_select(Entity)
+            .join(ContentHashMD5Component, Entity.id == ContentHashMD5Component.entity_id)
+            .where(ContentHashMD5Component.hash_value == hash_value)
+        )
+    else:
+        logger.error(f"Unsupported hash type for search: {hash_type}")
+        return None
+    result = session.execute(stmt).scalar_one_or_none()
+    return result
+
+
+@listens_for(AssetFileIngestionRequested)
+async def handle_asset_file_ingestion_request(
+    event: AssetFileIngestionRequested,
+    session: Session,
+    # world_name parameter can be derived from event.world_name
+    # world_config parameter can be derived from app_config.settings.get_world_config(event.world_name)
+):
+    """
+    Handles the ingestion of an asset file by copying it.
+    Logic derived from asset_service.add_asset_file.
+    """
+    logger.info(f"Handling AssetFileIngestionRequested for: {event.original_filename} in world {event.world_name}")
+    created_new_entity = False
+    filepath_on_disk = event.filepath_on_disk
+    original_filename = event.original_filename
+    mime_type = event.mime_type
+    size_bytes = event.size_bytes
+    world_name = event.world_name
+
+    try:
+        file_content = filepath_on_disk.read_bytes()
+    except IOError:
+        logger.exception(f"Error reading file {filepath_on_disk} for event {event}")
+        raise
+
+    world_config_obj: WorldConfig = app_config.settings.get_world_config(world_name)
+
+    content_hash_sha256, physical_storage_path_suffix = file_storage.store_file(
+        file_content, world_config=world_config_obj, original_filename=original_filename
+    )
+
+    existing_entity = _find_entity_by_content_hash(session, content_hash_sha256, "sha256")
+    entity: Optional[Entity] = None
+
+    if existing_entity:
+        entity = existing_entity
+        logger.info(
+            f"Content (SHA256: {content_hash_sha256[:12]}...) for '{original_filename}' "
+            f"already exists as Entity ID {entity.id}. Linking original source."
+        )
+        md5_hash_value = calculate_md5(filepath_on_disk)
+        existing_md5_components = ecs_service.get_components(session, entity.id, ContentHashMD5Component)
+        if not any(comp.hash_value == md5_hash_value for comp in existing_md5_components):
+            chc_md5 = ContentHashMD5Component(entity_id=entity.id, entity=entity, hash_value=md5_hash_value)
+            ecs_service.add_component_to_entity(session, entity.id, chc_md5)
+            logger.info(f"Added MD5 hash '{md5_hash_value}' to existing Entity ID {entity.id}.")
+
+        existing_cas_locations = ecs_service.get_components(session, entity.id, FileLocationComponent)
+        found_cas_location = False
+        for loc in existing_cas_locations:
+            if loc.storage_type == "local_cas" and loc.physical_path_or_key == physical_storage_path_suffix:
+                found_cas_location = True
+                break
+        if not found_cas_location:
+            flc = FileLocationComponent(
+                entity_id=entity.id, entity=entity, content_identifier=content_hash_sha256,
+                storage_type="local_cas", physical_path_or_key=physical_storage_path_suffix,
+                contextual_filename=original_filename,
+            )
+            ecs_service.add_component_to_entity(session, entity.id, flc)
+    else:
+        created_new_entity = True
+        entity = ecs_service.create_entity(session) # type: ignore
+        logger.info(
+            f"Creating new Entity ID {entity.id} for '{original_filename}' (SHA256: {content_hash_sha256[:12]}...)."
+        )
+        chc_sha256 = ContentHashSHA256Component(entity_id=entity.id, entity=entity, hash_value=content_hash_sha256)
+        ecs_service.add_component_to_entity(session, entity.id, chc_sha256)
+
+        md5_hash_value = calculate_md5(filepath_on_disk)
+        chc_md5 = ContentHashMD5Component(entity_id=entity.id, entity=entity, hash_value=md5_hash_value)
+        ecs_service.add_component_to_entity(session, entity.id, chc_md5)
+
+        fpc = FilePropertiesComponent(
+            entity_id=entity.id, entity=entity, original_filename=original_filename,
+            file_size_bytes=size_bytes, mime_type=mime_type,
+        )
+        ecs_service.add_component_to_entity(session, entity.id, fpc)
+
+        flc = FileLocationComponent(
+            entity_id=entity.id, entity=entity, content_identifier=content_hash_sha256,
+            storage_type="local_cas", physical_path_or_key=physical_storage_path_suffix,
+            contextual_filename=original_filename,
+        )
+        ecs_service.add_component_to_entity(session, entity.id, flc)
+
+    if not entity:
+        logger.error(f"Entity object not available after processing {original_filename}. This is unexpected.")
+        raise Exception(f"Entity creation/retrieval failed for {original_filename}")
+
+    osi_comp = OriginalSourceInfoComponent(
+        entity_id=entity.id, entity=entity, original_filename=original_filename,
+        original_path=str(filepath_on_disk.resolve()),
+    )
+    ecs_service.add_component_to_entity(session, entity.id, osi_comp)
+
+    if mime_type and mime_type.startswith("image/"):
+        perceptual_hashes = generate_perceptual_hashes(filepath_on_disk)
+        if "phash" in perceptual_hashes and not ecs_service.get_components_by_value(session, entity.id, ImagePerceptualPHashComponent, {"hash_value": perceptual_hashes["phash"]}): #type: ignore
+            iphc = ImagePerceptualPHashComponent(entity_id=entity.id, entity=entity, hash_value=perceptual_hashes["phash"])
+            ecs_service.add_component_to_entity(session, entity.id, iphc)
+        if "ahash" in perceptual_hashes and not ecs_service.get_components_by_value(session, entity.id, ImagePerceptualAHashComponent, {"hash_value": perceptual_hashes["ahash"]}): #type: ignore
+            iahc = ImagePerceptualAHashComponent(entity_id=entity.id, entity=entity, hash_value=perceptual_hashes["ahash"])
+            ecs_service.add_component_to_entity(session, entity.id, iahc)
+        if "dhash" in perceptual_hashes and not ecs_service.get_components_by_value(session, entity.id, ImagePerceptualDHashComponent, {"hash_value": perceptual_hashes["dhash"]}): #type: ignore
+            idhc = ImagePerceptualDHashComponent(entity_id=entity.id, entity=entity, hash_value=perceptual_hashes["dhash"])
+            ecs_service.add_component_to_entity(session, entity.id, idhc)
+
+    if not ecs_service.get_components(session, entity.id, NeedsMetadataExtractionComponent):
+        marker_comp = NeedsMetadataExtractionComponent(entity_id=entity.id, entity=entity)
+        ecs_service.add_component_to_entity(session, entity.id, marker_comp, flush=True)
+        logger.info(f"Marked Entity ID {entity.id} with NeedsMetadataExtractionComponent.")
+
+    logger.info(f"Finished handling AssetFileIngestionRequested for Entity ID {entity.id}. New entity: {created_new_entity}")
+
+
+@listens_for(AssetReferenceIngestionRequested)
+async def handle_asset_reference_ingestion_request(
+    event: AssetReferenceIngestionRequested,
+    session: Session,
+):
+    """
+    Handles the ingestion of an asset by reference.
+    Logic derived from asset_service.add_asset_reference.
+    """
+    logger.info(f"Handling AssetReferenceIngestionRequested for: {event.original_filename} in world {event.world_name}")
+    created_new_entity = False
+    filepath_on_disk = event.filepath_on_disk
+    original_filename = event.original_filename
+    mime_type = event.mime_type
+    size_bytes = event.size_bytes
+
+    try:
+        content_hash_sha256 = calculate_sha256(filepath_on_disk)
+        content_hash_md5 = calculate_md5(filepath_on_disk)
+    except IOError:
+        logger.exception(f"Error reading file for hashing: {filepath_on_disk} for event {event}")
+        raise
+
+    existing_entity = _find_entity_by_content_hash(session, content_hash_sha256, "sha256")
+    entity: Optional[Entity] = None
+
+    if existing_entity:
+        entity = existing_entity
+        logger.info(
+            f"Content (SHA256: {content_hash_sha256[:12]}...) for '{original_filename}' "
+            f"already exists as Entity ID {entity.id}. Adding new reference."
+        )
+        existing_md5_components = ecs_service.get_components(session, entity.id, ContentHashMD5Component)
+        if not any(comp.hash_value == content_hash_md5 for comp in existing_md5_components):
+            chc_md5 = ContentHashMD5Component(entity_id=entity.id, entity=entity, hash_value=content_hash_md5)
+            ecs_service.add_component_to_entity(session, entity.id, chc_md5)
+    else:
+        created_new_entity = True
+        entity = ecs_service.create_entity(session) # type: ignore
+        logger.info(
+            f"Creating new Entity ID {entity.id} for referenced file '{original_filename}' "
+            f"(SHA256: {content_hash_sha256[:12]}...)."
+        )
+        chc_sha256 = ContentHashSHA256Component(entity_id=entity.id, entity=entity, hash_value=content_hash_sha256)
+        ecs_service.add_component_to_entity(session, entity.id, chc_sha256)
+
+        chc_md5 = ContentHashMD5Component(entity_id=entity.id, entity=entity, hash_value=content_hash_md5)
+        ecs_service.add_component_to_entity(session, entity.id, chc_md5)
+
+        fpc = FilePropertiesComponent(
+            entity_id=entity.id, entity=entity, original_filename=original_filename,
+            file_size_bytes=size_bytes, mime_type=mime_type,
+        )
+        ecs_service.add_component_to_entity(session, entity.id, fpc)
+
+    if not entity:
+        logger.error(f"Entity object not available after processing reference {original_filename}. This is unexpected.")
+        raise Exception(f"Entity creation/retrieval failed for reference {original_filename}")
+
+    resolved_original_path = str(filepath_on_disk.resolve())
+
+    existing_locations = ecs_service.get_components(session, entity.id, FileLocationComponent)
+    found_ref_location = any(
+        loc.storage_type == "local_reference" and loc.physical_path_or_key == resolved_original_path
+        for loc in existing_locations
+    )
+
+    if not found_ref_location:
+        flc = FileLocationComponent(
+            entity_id=entity.id, entity=entity, content_identifier=content_hash_sha256,
+            storage_type="local_reference", physical_path_or_key=resolved_original_path,
+            contextual_filename=original_filename,
+        )
+        ecs_service.add_component_to_entity(session, entity.id, flc)
+        logger.info(f"Added new FileLocationComponent (local_reference) for path '{resolved_original_path}' to Entity ID {entity.id}.")
+
+    osi_comp = OriginalSourceInfoComponent(
+        entity_id=entity.id, entity=entity, original_filename=original_filename,
+        original_path=resolved_original_path,
+    )
+    ecs_service.add_component_to_entity(session, entity.id, osi_comp)
+
+    if mime_type and mime_type.startswith("image/"):
+        perceptual_hashes = generate_perceptual_hashes(filepath_on_disk)
+        if "phash" in perceptual_hashes and not ecs_service.get_components_by_value(session, entity.id, ImagePerceptualPHashComponent, {"hash_value": perceptual_hashes["phash"]}): #type: ignore
+            iphc = ImagePerceptualPHashComponent(entity_id=entity.id, entity=entity, hash_value=perceptual_hashes["phash"])
+            ecs_service.add_component_to_entity(session, entity.id, iphc)
+        if "ahash" in perceptual_hashes and not ecs_service.get_components_by_value(session, entity.id, ImagePerceptualAHashComponent, {"hash_value": perceptual_hashes["ahash"]}): #type: ignore
+            iahc = ImagePerceptualAHashComponent(entity_id=entity.id, entity=entity, hash_value=perceptual_hashes["ahash"])
+            ecs_service.add_component_to_entity(session, entity.id, iahc)
+        if "dhash" in perceptual_hashes and not ecs_service.get_components_by_value(session, entity.id, ImagePerceptualDHashComponent, {"hash_value": perceptual_hashes["dhash"]}): #type: ignore
+            idhc = ImagePerceptualDHashComponent(entity_id=entity.id, entity=entity, hash_value=perceptual_hashes["dhash"])
+            ecs_service.add_component_to_entity(session, entity.id, idhc)
+
+    if not ecs_service.get_components(session, entity.id, NeedsMetadataExtractionComponent):
+        marker_comp = NeedsMetadataExtractionComponent(entity_id=entity.id, entity=entity)
+        ecs_service.add_component_to_entity(session, entity.id, marker_comp, flush=True)
+        logger.info(f"Marked Entity ID {entity.id} with NeedsMetadataExtractionComponent for referenced asset.")
+
+    logger.info(f"Finished handling AssetReferenceIngestionRequested for Entity ID {entity.id}. New entity: {created_new_entity}")
+
+__all__ = [
+    "handle_asset_file_ingestion_request",
+    "handle_asset_reference_ingestion_request",
+]

--- a/dam/systems/metadata_systems.py
+++ b/dam/systems/metadata_systems.py
@@ -7,9 +7,9 @@ metadata such as dimensions, duration, frame counts, audio properties, etc.,
 using tools like the Hachoir library.
 """
 import asyncio
-import logging  # Changed back to logging
+import logging
 from pathlib import Path
-from typing import List, Annotated  # Import Annotated and List for the type hint
+from typing import List, Annotated, Any # Added Any
 
 from dam.core.components_markers import NeedsMetadataExtractionComponent
 from dam.core.stages import SystemStage
@@ -17,18 +17,17 @@ from dam.core.system_params import (
     CurrentWorldConfig,
     WorldSession,
 )
-from dam.core.systems import system  # Assuming @system decorator is in dam.core.systems
+from dam.core.systems import system
 from dam.models import (
     AudioPropertiesComponent,
     Entity,
-    FileLocationComponent,  # Import FileLocationComponent
+    FileLocationComponent,
     FilePropertiesComponent,
     FramePropertiesComponent,
     ImageDimensionsComponent,
 )
-from dam.services import ecs_service  # For get_component, add_component_to_entity, remove_component
+from dam.services import ecs_service
 
-# Hachoir for metadata extraction (can be kept here or moved to a utility if widely used)
 try:
     from hachoir.core import config as HachoirConfig
     from hachoir.metadata import extractMetadata
@@ -42,36 +41,28 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-# Helper functions for Hachoir metadata (kept local to this system module)
 def _has_hachoir_metadata(md, key: str) -> bool:
     """Safely checks if Hachoir metadata object has a given key."""
     try:
         return md.has(key)
-    except (KeyError, ValueError): # Hachoir can sometimes raise ValueError for invalid keys/access
+    except (KeyError, ValueError):
         return False
 
 
 def _get_hachoir_metadata(md, key: str, default=None) -> Any:
     """Safely gets a value from Hachoir metadata object for a given key."""
     try:
-        if md.has(key): # Check first to avoid potential exceptions from get() on some metadata items
+        if md.has(key):
             return md.get(key)
-    except (KeyError, ValueError): # Hachoir can sometimes raise ValueError
+    except (KeyError, ValueError):
         pass
     return default
 
 
-def _extract_metadata_with_hachoir_sync(filepath_on_disk: Path) -> Any | None:  # Changed to def
+async def _extract_metadata_with_hachoir_sync(filepath_on_disk: Path) -> Any | None:
     """
     Synchronous part of Hachoir metadata extraction.
-    This function is intended to be run in a separate thread using `asyncio.to_thread`
-    to avoid blocking the main asyncio event loop, as Hachoir operations can be I/O bound.
-
-    Args:
-        filepath_on_disk: The path to the file from which to extract metadata.
-
-    Returns:
-        A Hachoir metadata object if successful, otherwise None.
+    Run in a separate thread using `asyncio.to_thread`.
     """
     if not createParser or not extractMetadata:
         logger.info("Hachoir library not available. Cannot perform sync extraction.")
@@ -91,26 +82,21 @@ def _extract_metadata_with_hachoir_sync(filepath_on_disk: Path) -> Any | None:  
             return None
 
 
-# from typing import Annotated # Moved to top
-
-
 @system(stage=SystemStage.METADATA_EXTRACTION)
 async def extract_metadata_on_asset_ingested(
-    session: WorldSession,  # Injected SQLAlchemy Session
-    world_config: CurrentWorldConfig,  # Injected WorldConfig
+    session: WorldSession,
+    world_config: CurrentWorldConfig,
     entities_to_process: Annotated[
         List[Entity], "MarkedEntityList", NeedsMetadataExtractionComponent
-    ],  # Corrected usage
-    # file_ops: Resource[FileOperationsResource] # If direct file ops are needed beyond path resolution
+    ],
 ):
     if not createParser or not extractMetadata:
         logger.warning("Hachoir library not installed. Skipping metadata extraction system.")
-        # Remove marker components even if Hachoir is not available to prevent re-processing attempts
         for entity in entities_to_process:
             marker = ecs_service.get_component(session, entity.id, NeedsMetadataExtractionComponent)
             if marker:
                 ecs_service.remove_component(session, marker, flush=False)
-        if entities_to_process:  # Only flush if there were components to remove
+        if entities_to_process:
             session.flush()
         return
 
@@ -128,15 +114,12 @@ async def extract_metadata_on_asset_ingested(
         file_props = ecs_service.get_component(session, entity.id, FilePropertiesComponent)
         if not file_props:
             logger.warning(f"No FilePropertiesComponent found for Entity ID {entity.id}. Cannot extract metadata.")
-            # Remove marker and continue
             marker = ecs_service.get_component(session, entity.id, NeedsMetadataExtractionComponent)
             if marker:
                 ecs_service.remove_component(session, marker, flush=False)
             continue
 
         mime_type = file_props.mime_type
-
-        # Determine the filepath_on_disk
         all_locations = ecs_service.get_components(session, entity.id, FileLocationComponent)
         if not all_locations:
             logger.warning(f"No FileLocationComponent found for Entity ID {entity.id}. Cannot extract metadata.")
@@ -165,15 +148,12 @@ async def extract_metadata_on_asset_ingested(
             continue
 
         logger.info(f"Extracting metadata from {filepath_on_disk} for Entity ID {entity.id} (MIME: {mime_type})")
-
-        # Run Hachoir parsing in a separate thread
         metadata = await asyncio.to_thread(_extract_metadata_with_hachoir_sync, filepath_on_disk)
 
         if not metadata:
             logger.info(f"No metadata extracted by Hachoir for {filepath_on_disk} (Entity ID {entity.id})")
         else:
             logger.debug(f"Hachoir metadata keys for {filepath_on_disk}: {[item for item in metadata]}")
-            # --- Populate ImageDimensionsComponent ---
             if mime_type.startswith("image/") or mime_type.startswith("video/"):
                 if not ecs_service.get_components(session, entity.id, ImageDimensionsComponent):
                     width = _get_hachoir_metadata(metadata, "width")
@@ -189,7 +169,6 @@ async def extract_metadata_on_asset_ingested(
                             f"Could not extract width/height for visual media Entity ID {entity.id} (MIME: {mime_type})"
                         )
 
-            # --- Heuristics and other components (Audio, Frame) ---
             has_duration = _has_hachoir_metadata(metadata, "duration")
             has_width = _has_hachoir_metadata(metadata, "width")
             has_frame_rate = _has_hachoir_metadata(metadata, "frame_rate")
@@ -197,9 +176,8 @@ async def extract_metadata_on_asset_ingested(
             has_sample_rate = _has_hachoir_metadata(metadata, "sample_rate")
 
             is_video_heuristic = mime_type.startswith("video/") or (has_duration and (has_width or has_frame_rate))
-
             is_audio_file_heuristic = False
-            if mime_type == "image/gif":  # GIFs are not audio files
+            if mime_type == "image/gif":
                 is_audio_file_heuristic = False
             elif mime_type.startswith("audio/"):
                 is_audio_file_heuristic = True
@@ -210,9 +188,7 @@ async def extract_metadata_on_asset_ingested(
 
             if is_audio_file_heuristic:
                 if not ecs_service.get_components(session, entity.id, AudioPropertiesComponent):
-                    # ... (populate and add AudioPropertiesComponent, same as before) ...
-                    # This part needs to be filled in with the original logic for AudioProperties
-                    audio_comp = AudioPropertiesComponent(entity_id=entity.id, entity=entity)  # Ensure entity is passed
+                    audio_comp = AudioPropertiesComponent(entity_id=entity.id, entity=entity)
                     duration = _get_hachoir_metadata(metadata, "duration")
                     if duration:
                         audio_comp.duration_seconds = duration.total_seconds()
@@ -230,7 +206,6 @@ async def extract_metadata_on_asset_ingested(
 
             if is_video_heuristic:
                 if not ecs_service.get_components(session, entity.id, FramePropertiesComponent):
-                    # ... (populate and add FramePropertiesComponent for video, same as before) ...
                     video_frame_comp = FramePropertiesComponent(entity_id=entity.id, entity=entity)
                     video_duration = _get_hachoir_metadata(metadata, "duration")
                     nb_frames = _get_hachoir_metadata(metadata, "nb_frames") or _get_hachoir_metadata(
@@ -253,11 +228,8 @@ async def extract_metadata_on_asset_ingested(
 
                 if _has_hachoir_metadata(metadata, "audio_codec"):
                     if not ecs_service.get_components(session, entity.id, AudioPropertiesComponent):
-                        # ... (populate and add AudioPropertiesComponent for video's audio, same as before) ...
                         video_audio_comp = AudioPropertiesComponent(entity_id=entity.id, entity=entity)
-                        video_duration_audio = _get_hachoir_metadata(
-                            metadata, "duration"
-                        )  # Use a different var name to avoid conflict
+                        video_duration_audio = _get_hachoir_metadata(metadata, "duration")
                         if video_duration_audio:
                             video_audio_comp.duration_seconds = video_duration_audio.total_seconds()
                         video_audio_comp.codec_name = _get_hachoir_metadata(metadata, "audio_codec")
@@ -268,13 +240,12 @@ async def extract_metadata_on_asset_ingested(
 
             if mime_type == "image/gif":
                 if not ecs_service.get_components(session, entity.id, FramePropertiesComponent):
-                    # ... (populate and add FramePropertiesComponent for GIF, same as before) ...
                     frame_comp = FramePropertiesComponent(entity_id=entity.id, entity=entity)
                     nb_frames_gif = _get_hachoir_metadata(metadata, "nb_frames") or _get_hachoir_metadata(
                         metadata, "frame_count"
-                    )  # Use a different var name
+                    )
                     frame_comp.frame_count = nb_frames_gif
-                    duration_gif = _get_hachoir_metadata(metadata, "duration")  # Use a different var name
+                    duration_gif = _get_hachoir_metadata(metadata, "duration")
                     if nb_frames_gif and nb_frames_gif > 1 and duration_gif:
                         duration_sec = duration_gif.total_seconds()
                         frame_comp.animation_duration_seconds = duration_sec
@@ -283,15 +254,9 @@ async def extract_metadata_on_asset_ingested(
                     ecs_service.add_component_to_entity(session, entity.id, frame_comp, flush=False)
                     logger.info(f"Added FramePropertiesComponent for animated GIF Entity ID {entity.id}")
 
-        # Remove the marker component after processing
         marker = ecs_service.get_component(session, entity.id, NeedsMetadataExtractionComponent)
         if marker:
-            ecs_service.remove_component(session, marker, flush=False)  # Batch flush at end of stage
+            ecs_service.remove_component(session, marker, flush=False)
             logger.debug(f"Removed NeedsMetadataExtractionComponent from Entity ID {entity.id}")
 
-    # Session flush/commit will be handled by the WorldScheduler after the stage execution
-    # or after each system if configured that way. For now, assuming after stage.
-    # The remove_component calls above use flush=False.
-    # The WorldScheduler's current implementation does a flush after removing markers for a system,
-    # and then a commit at the end of the stage.
     logger.info("MetadataExtractionSystem finished processing entities.")


### PR DESCRIPTION
This commit includes the work-in-progress for refactoring the asset ingestion mechanism to an event-driven architecture, inspired by Bevy's ECS event system.

Key changes and steps taken so far:

1.  **Environment Setup**:
    *   Initialized `uv venv`.
    *   Installed dependencies from `pyproject.toml`, including ensuring `pytest-asyncio` is part of `dev` dependencies.
    *   Configured git to ignore alembic files as requested.

2.  **Codebase Exploration**:
    *   Reviewed `asset_service.py`, `cli.py`, `core/systems.py`, `README.md`, and `AGENTS.md`.
    *   Formulated a plan to introduce events for asset ingestion.

3.  **Event-Driven Refactoring**:
    *   Created `dam/core/events.py` defining `AssetFileIngestionRequested` and `AssetReferenceIngestionRequested` events.
    *   Extended `dam/core/systems.py` (`WorldScheduler`):
        *   Added an `EVENT_HANDLER_REGISTRY`.
        *   Introduced a `@listens_for(EventType)` decorator.
        *   Implemented `dispatch_event(event, world_context)` method to process events and manage transactions.
        *   Refactored parameter parsing and system execution logic into `_resolve_and_execute_system` and `_parse_system_params` helpers.
    *   Created `dam/systems/asset_ingestion_systems.py` with:
        *   `handle_asset_file_ingestion_request` system listening for `AssetFileIngestionRequested`.
        *   `handle_asset_reference_ingestion_request` system listening for `AssetReferenceIngestionRequested`.
        *   These systems contain the core logic moved from `asset_service.py`.
    *   Updated `dam/systems/__init__.py` to use `importlib` to load system modules, including the new `asset_ingestion_systems`.
    *   Modified `dam/cli.py` (`cli_add_asset` command) to dispatch these events instead of calling `asset_service` functions directly.

4.  **Test Updates and Debugging (In Progress)**:
    *   Began refactoring `tests/services/test_asset_service.py` to align with the event-driven approach (making tests `async`, dispatching events, and running necessary stages).
    *   Encountered and addressed several issues during test collection and execution:
        *   Fixed `NameError` for `Optional` and `Any` in core and system files by adding necessary `typing` imports.
        *   Fixed `SyntaxError` (variable name typo) in `dam/systems/metadata_systems.py`.
        *   Attempted to fix a recurring `SyntaxError` in `tests/test_cli.py` related to a stray end-of-file marker. This issue appeared multiple times in reports, suggesting potential problems with file state synchronization or tool behavior.
        *   Addressed a `ModuleNotFoundError` for `dam.systems.asset_ingestion_systems` by ensuring the file was created in the correct location (`dam/systems/`) after it was found to be missing.
        *   Ensured `pytest-asyncio` was installed to resolve `PytestUnknownMarkWarning`.

Current Sticking Point:
The primary challenge is a persistent test collection error. Despite several attempts to fix a reported `SyntaxError` in `tests/test_cli.py` (related to an unexpected end-of-file marker) and ensuring `dam/systems/asset_ingestion_systems.py` exists, `pytest` still fails during collection, often pointing back to the `tests/test_cli.py` syntax issue or the `ModuleNotFoundError` for `asset_ingestion_systems.py` if the `SyntaxError` is temporarily bypassed.

The `uv run pytest ... | awk ...` command has also been unreliably showing output, making it harder to pinpoint the exact first failure when collection issues occur. Direct `pytest` invocation has been more helpful.

It seems there might be a deeper issue with either the state of `tests/test_cli.py` in the environment or a subtle problem within `asset_ingestion_systems.py` (or its imports) that causes `importlib` to fail in `dam/systems/__init__.py`, even if the file exists. The recurring nature of the `SyntaxError` in `tests/test_cli.py` in error reports, even after fixes, is particularly puzzling and suggests that the file might not be getting updated correctly in the test environment, or the error reports are misleading due to cascading failures.

Further diagnosis would involve meticulously verifying file contents in the environment and potentially simplifying imports in `asset_ingestion_systems.py` to isolate any internal issues.