### PR TITLE
Refactor tests, fix issues, and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,11 @@ dam-cli --help
     dam-cli add-asset /path/to/your/document.pdf
     ```
 
-*   **`find-file-by-hash <hash_value>`**: Finds an asset by its content hash and displays its properties. This includes:
-    *   Basic file properties (name, size, MIME type from `FilePropertiesComponent`).
-    *   Content hashes (MD5, SHA256).
-    *   File Locations (`FileLocationComponent`): Displays contextual filename, content ID, path/key, and storage type for each location.
+*   **`find-file-by-hash <hash_value>`**: Finds an asset by its content hash and displays its properties directly to the console. This includes:
+    *   Entity ID.
+    *   Basic file properties (original filename, size, MIME type from `FilePropertiesComponent`).
+    *   Content hashes (MD5, SHA256 from `ContentHashMD5Component`, `ContentHashSHA256Component`).
+    *   File Locations (`FileLocationComponent`): Displays contextual filename, content identifier (hash), physical path/key, and storage type (e.g., `local_cas`, `local_reference`) for each location.
     *   Image dimensions (width, height) for visual assets.
     *   Frame properties (frame count, rate, duration) for videos and animated GIFs.
     *   Audio properties (codec, duration, sample rate) for audio files and audio tracks within videos.
@@ -181,7 +182,7 @@ dam-cli --help
     dam-cli find-file-by-hash --file /path/to/somefile.txt --hash-type md5
     ```
 
-*   **`find-similar-images <image_filepath>`**: Finds images similar to the provided image based on perceptual hashes.
+*   **`find-similar-images <image_filepath>`**: Finds images similar to the provided image based on perceptual hashes and displays the results to the console. Results include Entity ID, filename, distance, and hash type for each match.
     *   `--phash-threshold <int>`: Max Hamming distance for pHash (default: 4).
     *   `--ahash-threshold <int>`: Max Hamming distance for aHash (default: 4).
     *   `--dhash-threshold <int>`: Max Hamming distance for dHash (default: 4).

--- a/dam/core/events.py
+++ b/dam/core/events.py
@@ -86,7 +86,7 @@ class FindEntityByHashQuery(BaseEvent):
     hash_type: str = "sha256"  # Moved to the end as it has a default
 
     # For carrying results if the system modifies the event or posts a new one
-    # result_entity_id: Optional[int] = field(default=None, init=False)
+    result: Optional[dict] = None  # field(default=None, init=False) might be better if we don't want it in __init__
 
 
 @dataclass
@@ -101,7 +101,7 @@ class FindSimilarImagesQuery(BaseEvent):
     request_id: str  # Unique ID for this query request
 
     # For carrying results
-    # result_similar_entities_info: Optional[list[dict]] = field(default=None, init=False)
+    result: Optional[list] = None  # field(default=None, init=False)
 
 
 # To allow __init__.py in dam/core to import these

--- a/dam/systems/metadata_systems.py
+++ b/dam/systems/metadata_systems.py
@@ -179,9 +179,7 @@ async def extract_metadata_on_asset_ingested(
                     width = _get_hachoir_metadata(metadata, "width")
                     height = _get_hachoir_metadata(metadata, "height")
                     if width is not None and height is not None:
-                        dim_comp = ImageDimensionsComponent(
-                            entity_id=entity.id, entity=entity, width_pixels=width, height_pixels=height
-                        )
+                        dim_comp = ImageDimensionsComponent(entity=entity, width_pixels=width, height_pixels=height)
                         ecs_service.add_component_to_entity(session, entity.id, dim_comp, flush=False)
                         logger.info(f"Added ImageDimensionsComponent ({width}x{height}) for Entity ID {entity.id}")
                     else:
@@ -222,7 +220,7 @@ async def extract_metadata_on_asset_ingested(
 
             if is_audio_file_heuristic:  # Standalone audio file
                 if not ecs_service.get_components(session, entity.id, AudioPropertiesComponent):
-                    audio_comp = AudioPropertiesComponent(entity_id=entity.id, entity=entity)
+                    audio_comp = AudioPropertiesComponent(entity=entity)
                     duration = _get_hachoir_metadata(metadata, "duration")
                     if duration:
                         audio_comp.duration_seconds = duration.total_seconds()
@@ -245,7 +243,7 @@ async def extract_metadata_on_asset_ingested(
 
             if is_video_heuristic:  # Video file or animated image with frames/duration
                 if not ecs_service.get_components(session, entity.id, FramePropertiesComponent):
-                    video_frame_comp = FramePropertiesComponent(entity_id=entity.id, entity=entity)
+                    video_frame_comp = FramePropertiesComponent(entity=entity)
 
                     nb_frames = _get_hachoir_metadata(metadata, "nb_frames") or _get_hachoir_metadata(
                         metadata, "frame_count"
@@ -273,7 +271,7 @@ async def extract_metadata_on_asset_ingested(
 
                 # If video, check for embedded audio stream
                 if has_audio_codec and not ecs_service.get_components(session, entity.id, AudioPropertiesComponent):
-                    video_audio_comp = AudioPropertiesComponent(entity_id=entity.id, entity=entity)
+                    video_audio_comp = AudioPropertiesComponent(entity=entity)
                     video_duration_audio = _get_hachoir_metadata(metadata, "duration")  # Use overall duration
                     if video_duration_audio:
                         video_audio_comp.duration_seconds = video_duration_audio.total_seconds()
@@ -290,7 +288,7 @@ async def extract_metadata_on_asset_ingested(
                 if not ecs_service.get_components(
                     session, entity.id, FramePropertiesComponent
                 ):  # Check again if not caught by video heuristic
-                    frame_comp = FramePropertiesComponent(entity_id=entity.id, entity=entity)
+                    frame_comp = FramePropertiesComponent(entity=entity)
                     nb_frames_gif = _get_hachoir_metadata(metadata, "nb_frames") or _get_hachoir_metadata(
                         metadata, "frame_count"
                     )


### PR DESCRIPTION
This commit includes several key improvements:

1.  **Test Refactoring**:
    *   Tests in `tests/test_cli.py` were refactored to be less reliant on exact log output and stdout formatting.
    *   Assertions now focus more on verifying command exit codes, side effects (file creation, CAS storage), and database state.
    *   Dummy image generation (`_create_dummy_image`) was improved to provide better differentiation for perceptual hash testing.

2.  **Code Fixes**:
    *   Resolved various `ImportError`, `AttributeError`, and `IndentationError` issues in tests that arose from an outdated understanding of the main codebase.
    *   Corrected attribute names for several SQLAlchemy models (e.g., `ContentHashSHA256Component.hash_value`, `FileLocationComponent.contextual_filename`, `FileLocationComponent.physical_path_or_key`).
    *   Ensured correct types (bytes vs. hex strings) are used for hash value comparisons.
    *   Fixed component constructor calls in systems (e.g., `ImageDimensionsComponent`) to pass the `entity` object instead of `entity_id`, aligning with `BaseComponent`'s `init=False` for `entity_id`.
    *   Updated `storage_type` values in tests to match implementation (e.g., "local_cas", "local_reference").
    *   Modified CLI query commands (`find-file-by-hash`, `find-similar-images`) and their backing event/system handlers to return detailed results directly to the console, rather than just logging them. This involved adding a `result` field to the respective query event dataclasses.

3.  **Documentation Updates**:
    *   `README.md`: Updated descriptions for `find-file-by-hash` and `find-similar-images` CLI commands to reflect that they now output detailed results.
    *   `doc/developer_guide.md`:
        *   Clarified component constructor conventions (passing `entity` object).
        *   Updated examples and descriptions of component attributes (`FileLocationComponent`, `ContentHashSHA256Component`) to match current model definitions.
        *   Corrected `storage_type` examples.

All tests are passing after these changes. The codebase is now more robust, and the documentation more accurately reflects its behavior.