### PR TITLE
feat: Implement all major CLI operations in PyQt6 UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ ecs_dam_system/
 ├── dam/
 │   ├── __init__.py
 │   ├── cli.py              # Typer CLI application
+│   ├── ui/                 # PyQt6 UI code
+│   │   ├── __init__.py
+│   │   ├── main_window.py
+│   │   └── dialogs/        # Dialog windows for UI operations
+│   │       ├── __init__.py
+│   │       ├── add_asset_dialog.py
+│   │       ├── find_asset_by_hash_dialog.py
+│   │       ├── find_similar_images_dialog.py
+│   │       └── world_operations_dialogs.py
 │   ├── models/             # SQLAlchemy models (Components)
 │   │   ├── __init__.py
 │   │   └── ... (e.g., file_location_component.py)
@@ -93,6 +102,7 @@ ecs_dam_system/
     For optional features like perceptual image hashing and multimedia metadata extraction:
     - Image Hashing: `pip install -e ".[image]"` or `uv pip install -e ".[image]"`
     - The system uses `hachoir` for basic multimedia metadata extraction, which is included in the main dependencies.
+    - **For the PyQt6 User Interface:** `pip install -e ".[ui]"` or `uv pip install -e ".[ui]"`
 
 4.  **Set up environment variables:**
     *   Copy `.env.example` to `.env`:
@@ -198,6 +208,27 @@ dam-cli --help
     ```
 
 *   **`query-assets-placeholder`**: (Placeholder, hidden) For future component-based queries.
+
+*   **`ui`**: Launches the PyQt6-based graphical user interface for managing assets.
+    ```bash
+    dam-cli ui
+    ```
+    Make sure you have installed the UI dependencies: `pip install -e ".[ui]"` or `uv pip install -e ".[ui]"`.
+
+    The UI allows you to:
+    *   List assets from the currently selected DAM world.
+    *   Search for assets by filename.
+    *   Filter assets by their MIME type.
+    *   View all components of a selected asset by double-clicking it.
+    *   Add new assets (equivalent to `dam-cli add-asset`) via 'File > Add Asset(s)...'.
+    *   Find assets by content hash (equivalent to `dam-cli find-file-by-hash`) via 'File > Find Asset by Hash...'.
+    *   Find similar images (equivalent to `dam-cli find-similar-images`) via 'File > Find Similar Images...'.
+    *   Export the current world's data to a JSON file (equivalent to `dam-cli export-world`) via 'Tools > Export Current World...'.
+    *   Import data from a JSON file into the current world (equivalent to `dam-cli import-world`) via 'Tools > Import Data into Current World...'.
+    *   Merge another world into the current world (DB-to-DB, equivalent to `dam-cli merge-worlds-db`) via 'Tools > Merge Worlds...'.
+    *   Split the current world into two other worlds based on criteria (DB-to-DB, equivalent to `dam-cli split-world-db`) via 'Tools > Split Current World...'.
+    *   Set up the database for the current world (equivalent to `dam-cli setup-db`) via 'Tools > Setup Database for Current World...'.
+    *   The active world for these operations is determined by the `--world` CLI option, `DAM_CURRENT_WORLD` environment variable, or the default world setting, similar to other CLI commands.
 
 
 ## Development

--- a/dam/ui/__init__.py
+++ b/dam/ui/__init__.py
@@ -1,0 +1,1 @@
+# This file makes the dam/ui directory a Python package.

--- a/dam/ui/dialogs/__init__.py
+++ b/dam/ui/dialogs/__init__.py
@@ -1,0 +1,1 @@
+# This file makes the dam/ui/dialogs directory a Python package.

--- a/dam/ui/dialogs/add_asset_dialog.py
+++ b/dam/ui/dialogs/add_asset_dialog.py
@@ -1,0 +1,269 @@
+import asyncio
+from pathlib import Path
+from typing import Optional
+
+from PyQt6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QPushButton,
+    QLabel,
+    QLineEdit,
+    QCheckBox,
+    QFileDialog,
+    QMessageBox,
+    QFormLayout,
+)
+
+from dam.core.world import World
+from dam.core.events import AssetFileIngestionRequested, AssetReferenceIngestionRequested
+from dam.core.stages import SystemStage
+from dam.services import file_operations
+
+
+class AddAssetDialog(QDialog):
+    def __init__(self, current_world: World, parent=None):
+        super().__init__(parent)
+        self.current_world = current_world
+        self.setWindowTitle("Add New Asset(s)")
+        self.setMinimumWidth(500)
+
+        layout = QVBoxLayout(self)
+        form_layout = QFormLayout()
+
+        # File/Directory Path
+        self.path_input = QLineEdit()
+        self.browse_button = QPushButton("Browse...")
+        self.browse_button.clicked.connect(self.browse_path)
+        path_layout = QHBoxLayout()
+        path_layout.addWidget(self.path_input)
+        path_layout.addWidget(self.browse_button)
+        form_layout.addRow(QLabel("File/Directory Path:"), path_layout)
+
+        # Options
+        self.no_copy_checkbox = QCheckBox("Add by reference (do not copy to DAM storage)")
+        form_layout.addRow(self.no_copy_checkbox)
+
+        self.recursive_checkbox = QCheckBox("Process directory recursively")
+        self.recursive_checkbox.setEnabled(False) # Enabled when a directory is selected
+        form_layout.addRow(self.recursive_checkbox)
+
+        self.path_input.textChanged.connect(self.update_recursive_checkbox_state)
+
+        layout.addLayout(form_layout)
+
+        # Buttons
+        button_layout = QHBoxLayout()
+        self.add_button = QPushButton("Add Asset(s)")
+        self.add_button.clicked.connect(self.accept)
+        self.cancel_button = QPushButton("Cancel")
+        self.cancel_button.clicked.connect(self.reject)
+        button_layout.addStretch()
+        button_layout.addWidget(self.add_button)
+        button_layout.addWidget(self.cancel_button)
+        layout.addLayout(button_layout)
+
+        self.setLayout(layout)
+
+    def update_recursive_checkbox_state(self, text: str):
+        path = Path(text)
+        self.recursive_checkbox.setEnabled(path.is_dir())
+        if not path.is_dir() and self.recursive_checkbox.isChecked():
+            self.recursive_checkbox.setChecked(False)
+
+
+    def browse_path(self):
+        # Allow selecting either a file or a directory
+        # Start with QFileDialog.getOpenFileName and if user cancels, try QFileDialog.getExistingDirectory
+        # Or, have separate buttons, but a single smart one is often better.
+        # For simplicity, let's try a generic dialog that can select both, though Qt doesn't have one directly.
+        # We can use getExistingDirectory first, then getOpenFileName if user wants a file.
+        # Or, more simply, let user type/paste and validate.
+        # Let's try a simpler approach: offer two browse buttons or one that asks.
+        # For now, we'll make it intelligent based on what the user selects.
+
+        # Try to select a directory first. If the user cancels, try to select a file.
+        # This provides a somewhat unified experience, prioritizing directories.
+        dialog = QFileDialog(self, "Select Directory or File")
+        dialog.setFileMode(QFileDialog.FileMode.Directory) # Prioritize directory
+
+        # Try to make it more "any file or directory like"
+        # On some platforms, getOpenFileNames can select directories if configured right,
+        # but it's not standard. getExistingDirectory is explicit.
+
+        # Let's offer a choice via dialog mode or simply try one then the other.
+        # For this iteration, let's try a simpler approach that prioritizes directory selection.
+
+        path_str = QFileDialog.getExistingDirectory(self, "Select Directory to Add Assets From")
+        if path_str:
+            self.path_input.setText(path_str)
+            self.update_recursive_checkbox_state(path_str) # Ensure checkbox updates
+        else:
+            # If directory selection was cancelled, try file selection
+            path_str, _ = QFileDialog.getOpenFileName(self, "Select File to Add as Asset")
+            if path_str:
+                self.path_input.setText(path_str)
+                self.update_recursive_checkbox_state(path_str) # Ensure checkbox updates
+
+
+    def get_selected_options(self):
+        path_str = self.path_input.text().strip()
+        if not path_str:
+            QMessageBox.warning(self, "Input Error", "Please select a file or directory path.")
+            return None
+
+        path = Path(path_str)
+        if not path.exists():
+            QMessageBox.warning(self, "Input Error", f"Path does not exist: {path_str}")
+            return None
+
+        return {
+            "path": path,
+            "no_copy": self.no_copy_checkbox.isChecked(),
+            "recursive": self.recursive_checkbox.isChecked() if path.is_dir() else False,
+        }
+
+    def accept(self):
+        options = self.get_selected_options()
+        if not options:
+            return
+
+        path: Path = options["path"]
+        no_copy: bool = options["no_copy"]
+        recursive: bool = options["recursive"]
+
+        files_to_process: list[Path] = []
+        if path.is_file():
+            files_to_process.append(path)
+        elif path.is_dir():
+            if recursive:
+                files_to_process.extend(p for p in path.rglob("*") if p.is_file())
+            else:
+                files_to_process.extend(p for p in path.glob("*") if p.is_file())
+
+        if not files_to_process:
+            QMessageBox.information(self, "No Files", f"No files found to process at '{path}'.")
+            super().reject() # Close dialog if no files
+            return
+
+        # Show progress/summary later
+        processed_count = 0
+        error_count = 0
+
+        # This part should ideally run in a separate thread if processing many files
+        # For now, it will block the UI.
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        try:
+            for filepath in files_to_process:
+                try:
+                    original_filename, size_bytes, mime_type = file_operations.get_file_properties(filepath)
+
+                    event_to_dispatch: Optional[AssetFileIngestionRequested | AssetReferenceIngestionRequested] = None
+                    if no_copy:
+                        event_to_dispatch = AssetReferenceIngestionRequested(
+                            filepath_on_disk=filepath,
+                            original_filename=original_filename,
+                            mime_type=mime_type,
+                            size_bytes=size_bytes,
+                            world_name=self.current_world.name,
+                        )
+                    else:
+                        event_to_dispatch = AssetFileIngestionRequested(
+                            filepath_on_disk=filepath,
+                            original_filename=original_filename,
+                            mime_type=mime_type,
+                            size_bytes=size_bytes,
+                            world_name=self.current_world.name,
+                        )
+
+                    async def dispatch_and_run_stages_sync(): # Helper for asyncio.run
+                        if event_to_dispatch:
+                            await self.current_world.dispatch_event(event_to_dispatch)
+                            await self.current_world.execute_stage(SystemStage.METADATA_EXTRACTION)
+
+                    asyncio.run(dispatch_and_run_stages_sync())
+                    processed_count += 1
+                except Exception as e:
+                    error_count += 1
+                    # Log error, maybe collect them for a summary
+                    print(f"Error processing {filepath.name}: {e}") # Simple print for now
+
+            summary_message = f"Processed {processed_count} file(s)."
+            if error_count > 0:
+                summary_message += f"\nEncountered {error_count} error(s)."
+
+            QMessageBox.information(self, "Ingestion Complete", summary_message)
+            super().accept() # Close dialog and signal success
+
+        except Exception as e:
+            QMessageBox.critical(self, "Ingestion Error", f"An unexpected error occurred: {e}")
+            super().reject() # Close dialog on major failure
+        finally:
+            QApplication.restoreOverrideCursor()
+
+if __name__ == '__main__':
+    # This is for testing the dialog independently
+    # In a real app, you'd need a QApplication and a World instance
+    from PyQt6.QtWidgets import QApplication
+    import sys
+
+    # Mock World for testing
+    class MockWorld:
+        def __init__(self, name="test_world"):
+            self.name = name
+            print(f"MockWorld '{self.name}' initialized.")
+
+        async def dispatch_event(self, event):
+            print(f"MockWorld: Event dispatched: {type(event).__name__} for {event.original_filename}")
+            # Simulate some work
+            await asyncio.sleep(0.1)
+
+        async def execute_stage(self, stage):
+            print(f"MockWorld: Executing stage: {stage.name}")
+            await asyncio.sleep(0.1)
+
+        def get_db_session(self): # Required if any part tries to use it through world
+            class MockSession:
+                def __enter__(self): return self
+                def __exit__(self, type, value, traceback): pass
+                # Add other methods if needed by downstream calls during testing
+            return MockSession()
+
+
+    app = QApplication(sys.argv)
+
+    # Setup a mock world (replace with actual world loading if testing with real backend)
+    # This requires your project structure to be importable
+    try:
+        # Attempt to load a real world if configured, for more thorough testing
+        from dam.core import config as app_config
+        from dam.core.world import get_world, create_and_register_all_worlds_from_settings
+        from dam.core.world_setup import register_core_systems
+
+        worlds = create_and_register_all_worlds_from_settings(app_settings=app_config.settings)
+        for w in worlds: register_core_systems(w)
+
+        world_instance_to_use = None
+        if app_config.settings.DEFAULT_WORLD_NAME:
+            world_instance_to_use = get_world(app_config.settings.DEFAULT_WORLD_NAME)
+        elif worlds:
+            world_instance_to_use = worlds[0]
+
+        if not world_instance_to_use:
+            print("Using MockWorld as no real world could be loaded.")
+            world_instance_to_use = MockWorld("default_mock")
+
+    except ImportError:
+        print("Project modules not found, using basic MockWorld.")
+        world_instance_to_use = MockWorld("fallback_mock")
+    except Exception as e:
+        print(f"Error setting up real world for dialog test, using MockWorld: {e}")
+        world_instance_to_use = MockWorld("error_mock")
+
+
+    dialog = AddAssetDialog(current_world=world_instance_to_use)
+    if dialog.exec():
+        print("Add Asset Dialog accepted.")
+    else:
+        print("Add Asset Dialog cancelled.")
+    sys.exit(app.exec())

--- a/dam/ui/dialogs/find_asset_by_hash_dialog.py
+++ b/dam/ui/dialogs/find_asset_by_hash_dialog.py
@@ -1,0 +1,230 @@
+from PyQt6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QLabel, QLineEdit, QComboBox,
+    QFileDialog, QMessageBox, QFormLayout, QApplication
+)
+from PyQt6.QtCore import Qt
+from pathlib import Path
+import uuid
+import asyncio # For running async world events
+
+from dam.core.world import World
+from dam.core.events import FindEntityByHashQuery
+from dam.services import file_operations # For calculating hash from file
+from dam.ui.main_window import ComponentViewerDialog # Reuse for displaying results
+
+
+class FindAssetByHashDialog(QDialog):
+    def __init__(self, current_world: World, parent=None):
+        super().__init__(parent)
+        self.current_world = current_world
+        self.setWindowTitle("Find Asset by Content Hash")
+        self.setMinimumWidth(450)
+
+        layout = QVBoxLayout(self)
+        form_layout = QFormLayout()
+
+        # Hash Value Input
+        self.hash_value_input = QLineEdit()
+        form_layout.addRow(QLabel("Hash Value:"), self.hash_value_input)
+
+        # Hash Type ComboBox
+        self.hash_type_combo = QComboBox()
+        self.hash_type_combo.addItems(["sha256", "md5"])
+        form_layout.addRow(QLabel("Hash Type:"), self.hash_type_combo)
+
+        # Calculate from File (Optional)
+        self.file_path_input = QLineEdit()
+        self.file_path_input.setPlaceholderText("Optional: Select file to calculate hash from")
+        self.browse_file_button = QPushButton("Browse File...")
+        self.browse_file_button.clicked.connect(self.browse_for_file_to_hash)
+        file_hash_layout = QHBoxLayout()
+        file_hash_layout.addWidget(self.file_path_input)
+        file_hash_layout.addWidget(self.browse_file_button)
+        form_layout.addRow(QLabel("Calculate from File:"), file_hash_layout)
+
+        self.calculate_and_fill_hash_button = QPushButton("Calculate & Fill Hash")
+        self.calculate_and_fill_hash_button.clicked.connect(self.calculate_and_fill_hash)
+        form_layout.addRow(self.calculate_and_fill_hash_button)
+
+        layout.addLayout(form_layout)
+
+        # Buttons
+        button_layout = QHBoxLayout()
+        self.find_button = QPushButton("Find Asset")
+        self.find_button.clicked.connect(self.find_asset)
+        self.cancel_button = QPushButton("Cancel")
+        self.cancel_button.clicked.connect(self.reject)
+        button_layout.addStretch()
+        button_layout.addWidget(self.find_button)
+        button_layout.addWidget(self.cancel_button)
+        layout.addLayout(button_layout)
+
+        self.setLayout(layout)
+
+    def browse_for_file_to_hash(self):
+        path_str, _ = QFileDialog.getOpenFileName(self, "Select File to Calculate Hash")
+        if path_str:
+            self.file_path_input.setText(path_str)
+
+    def calculate_and_fill_hash(self):
+        filepath_str = self.file_path_input.text().strip()
+        if not filepath_str:
+            QMessageBox.warning(self, "Input Error", "Please select a file first to calculate its hash.")
+            return
+
+        filepath = Path(filepath_str)
+        if not filepath.is_file():
+            QMessageBox.warning(self, "Input Error", f"File does not exist or is not a file: {filepath_str}")
+            return
+
+        selected_hash_type = self.hash_type_combo.currentText()
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        try:
+            calculated_hash = ""
+            if selected_hash_type == "sha256":
+                calculated_hash = file_operations.calculate_sha256_hex(filepath) # Assuming hex output needed
+            elif selected_hash_type == "md5":
+                calculated_hash = file_operations.calculate_md5_hex(filepath) # Assuming hex output needed
+
+            self.hash_value_input.setText(calculated_hash)
+            QMessageBox.information(self, "Hash Calculated", f"Calculated {selected_hash_type} hash: {calculated_hash}")
+        except Exception as e:
+            QMessageBox.critical(self, "Hash Calculation Error", f"Could not calculate hash: {e}")
+        finally:
+            QApplication.restoreOverrideCursor()
+
+
+    def find_asset(self):
+        hash_value = self.hash_value_input.text().strip()
+        hash_type = self.hash_type_combo.currentText()
+
+        if not hash_value:
+            QMessageBox.warning(self, "Input Error", "Please enter a hash value.")
+            return
+
+        request_id = str(uuid.uuid4())
+        query_event = FindEntityByHashQuery(
+            hash_value=hash_value, # The service layer will handle hex string to bytes if needed
+            hash_type=hash_type,
+            world_name=self.current_world.name,
+            request_id=request_id,
+        )
+
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        try:
+            # Run the async event dispatch
+            async def dispatch_query_sync():
+                await self.current_world.dispatch_event(query_event)
+
+            asyncio.run(dispatch_query_sync())
+
+            QApplication.restoreOverrideCursor() # Restore cursor before showing dialogs
+
+            if query_event.result:
+                entity_id = query_event.result.get("entity_id")
+                components_data = query_event.result.get("components", {})
+
+                # We need to structure components_data like ComponentViewerDialog expects:
+                # Dict[str, List[Dict[str, Any]]]
+                # The event result is Dict[str, Dict[str, Any]] for single components
+                # or Dict[str, List[Dict[str,Any]]] for multi-instance components.
+                # We need to ensure it's always a list of dicts for each component type.
+
+                processed_components_data = {}
+                for comp_name, data in components_data.items():
+                    if isinstance(data, list):
+                        processed_components_data[comp_name] = data
+                    elif isinstance(data, dict): # Single instance component
+                        processed_components_data[comp_name] = [data]
+                    else: # Should not happen based on event structure
+                        print(f"Warning: Unexpected data type for component {comp_name} in FindEntityByHashQuery result.")
+                        processed_components_data[comp_name] = []
+
+
+                QMessageBox.information(self, "Asset Found", f"Asset found for Entity ID: {entity_id}.")
+                # Reuse ComponentViewerDialog to show the details
+                # It expects dict where values are lists of component instances (as dicts)
+                viewer_dialog = ComponentViewerDialog(entity_id, processed_components_data, self.current_world.name, self)
+                viewer_dialog.exec()
+                super().accept() # Close find dialog if asset found and viewed
+            else:
+                QMessageBox.information(self, "Not Found", f"No asset found for hash '{hash_value}' (type: {hash_type}).")
+        except Exception as e:
+            QApplication.restoreOverrideCursor()
+            QMessageBox.critical(self, "Find Asset Error", f"An error occurred: {e}")
+            # import traceback; print(traceback.format_exc()) # For debugging
+        finally:
+            if QApplication.overrideCursor() is not None: # Ensure cursor is restored
+                 QApplication.restoreOverrideCursor()
+
+
+if __name__ == '__main__':
+    from PyQt6.QtWidgets import QApplication
+    import sys
+
+    class MockWorld: # Same MockWorld as in add_asset_dialog.py for consistency
+        def __init__(self, name="test_world"):
+            self.name = name
+            print(f"MockWorld '{self.name}' initialized for FindAssetByHashDialog.")
+
+        async def dispatch_event(self, event: FindEntityByHashQuery):
+            print(f"MockWorld: Event dispatched: {type(event).__name__} for hash {event.hash_value}")
+            await asyncio.sleep(0.1)
+            # Simulate finding an asset
+            if event.hash_value == "found_hash_sha256" and event.hash_type == "sha256":
+                event.result = {
+                    "entity_id": 123,
+                    "components": {
+                        "FilePropertiesComponent": { # Single instance
+                            "original_filename": "test_image.jpg",
+                            "mime_type": "image/jpeg",
+                            "file_size_bytes": 10240
+                        },
+                        "ContentHashSHA256Component": { # Single instance
+                            "hash_value": "found_hash_sha256"
+                        },
+                        "SomeMultiInstanceComponent": [ # Example of multi-instance
+                           {"value": "instance1"},
+                           {"value": "instance2"}
+                        ]
+                    }
+                }
+            elif event.hash_value == "another_hash_md5" and event.hash_type == "md5":
+                 event.result = {
+                    "entity_id": 456,
+                    "components": {
+                        "FilePropertiesComponent": {
+                            "original_filename": "document.pdf",
+                            "mime_type": "application/pdf",
+                        }
+                    }
+                 }
+            else:
+                event.result = None # Not found
+            print(f"MockWorld: Event result set for request_id {event.request_id}")
+
+
+    app = QApplication(sys.argv)
+    # Setup a mock world
+    try:
+        from dam.core import config as app_config
+        from dam.core.world import get_world, create_and_register_all_worlds_from_settings
+        from dam.core.world_setup import register_core_systems
+
+        worlds = create_and_register_all_worlds_from_settings(app_settings=app_config.settings)
+        for w in worlds: register_core_systems(w)
+
+        world_instance_to_use = None
+        if app_config.settings.DEFAULT_WORLD_NAME: world_instance_to_use = get_world(app_config.settings.DEFAULT_WORLD_NAME)
+        elif worlds: world_instance_to_use = worlds[0]
+
+        if not world_instance_to_use: world_instance_to_use = MockWorld("default_mock_find")
+        else: print(f"Using REAL world for FindAssetByHashDialog test: {world_instance_to_use.name}")
+
+    except Exception as e:
+        print(f"Error setting up world for dialog test, using MockWorld: {e}")
+        world_instance_to_use = MockWorld("error_mock_find")
+
+    dialog = FindAssetByHashDialog(current_world=world_instance_to_use)
+    dialog.exec()
+    sys.exit(app.exec())

--- a/dam/ui/dialogs/find_similar_images_dialog.py
+++ b/dam/ui/dialogs/find_similar_images_dialog.py
@@ -1,0 +1,288 @@
+import asyncio
+from pathlib import Path
+import uuid
+from typing import Optional, List as TypingList, Dict, Any # Renamed List to TypingList
+
+from PyQt6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QLabel, QLineEdit, QFileDialog,
+    QMessageBox, QFormLayout, QSpinBox, QListWidget, QListWidgetItem, QApplication,
+    QSplitter # To show query image and results
+)
+from PyQt6.QtGui import QPixmap, QAction # For displaying query image preview
+from PyQt6.QtCore import Qt
+
+from dam.core.world import World
+from dam.core.events import FindSimilarImagesQuery
+# Assuming ComponentViewerDialog might be reused or a similar display for selected similar image
+from dam.ui.main_window import ComponentViewerDialog
+# For image preview, ensure Pillow is available or handle gracefully
+try:
+    from PIL import Image as PILImage
+    from PIL.ImageQt import ImageQt
+    _pil_available = True
+except ImportError:
+    _pil_available = False
+
+
+class FindSimilarImagesDialog(QDialog):
+    def __init__(self, current_world: World, parent=None):
+        super().__init__(parent)
+        self.current_world = current_world
+        self.setWindowTitle("Find Similar Images")
+        self.setMinimumWidth(700) # Increased width
+        self.setMinimumHeight(500)
+
+        main_layout = QVBoxLayout(self)
+
+        # Top part for image selection and parameters
+        form_area_layout = QFormLayout()
+
+        # Image Path
+        self.image_path_input = QLineEdit()
+        self.browse_image_button = QPushButton("Browse Image...")
+        self.browse_image_button.clicked.connect(self.browse_for_image)
+        image_path_layout = QHBoxLayout()
+        image_path_layout.addWidget(self.image_path_input)
+        image_path_layout.addWidget(self.browse_image_button)
+        form_area_layout.addRow(QLabel("Query Image:"), image_path_layout)
+
+        # Thresholds
+        self.phash_threshold_spin = QSpinBox()
+        self.phash_threshold_spin.setRange(0, 64)
+        self.phash_threshold_spin.setValue(4)
+        form_area_layout.addRow(QLabel("pHash Threshold:"), self.phash_threshold_spin)
+
+        self.ahash_threshold_spin = QSpinBox()
+        self.ahash_threshold_spin.setRange(0, 64)
+        self.ahash_threshold_spin.setValue(4)
+        form_area_layout.addRow(QLabel("aHash Threshold:"), self.ahash_threshold_spin)
+
+        self.dhash_threshold_spin = QSpinBox()
+        self.dhash_threshold_spin.setRange(0, 64)
+        self.dhash_threshold_spin.setValue(4)
+        form_area_layout.addRow(QLabel("dHash Threshold:"), self.dhash_threshold_spin)
+
+        main_layout.addLayout(form_area_layout)
+
+        # Splitter for image preview and results
+        self.splitter = QSplitter(Qt.Orientation.Horizontal)
+
+        # Image Preview Area
+        self.image_preview_label = QLabel("Image Preview")
+        self.image_preview_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.image_preview_label.setMinimumWidth(200) # Min width for preview
+        self.image_preview_label.setStyleSheet("border: 1px solid gray;")
+        self.splitter.addWidget(self.image_preview_label)
+
+        # Results List
+        self.results_list_widget = QListWidget()
+        self.results_list_widget.itemDoubleClicked.connect(self.view_result_details)
+        self.splitter.addWidget(self.results_list_widget)
+
+        self.splitter.setSizes([200, 500]) # Initial sizes for preview and list
+        main_layout.addWidget(self.splitter)
+
+        # Buttons
+        button_layout = QHBoxLayout()
+        self.find_button = QPushButton("Find Similar Images")
+        self.find_button.clicked.connect(self.find_similar)
+        self.cancel_button = QPushButton("Close") # Changed from Cancel to Close
+        self.cancel_button.clicked.connect(self.accept) # Accept will just close it
+        button_layout.addStretch()
+        button_layout.addWidget(self.find_button)
+        button_layout.addWidget(self.cancel_button)
+        main_layout.addLayout(button_layout)
+
+        self.setLayout(main_layout)
+        self.image_path_input.textChanged.connect(self.update_image_preview)
+
+
+    def browse_for_image(self):
+        path_str, _ = QFileDialog.getOpenFileName(self, "Select Query Image", "", "Images (*.png *.jpg *.jpeg *.bmp *.gif)")
+        if path_str:
+            self.image_path_input.setText(path_str)
+            # update_image_preview will be called by textChanged signal
+
+    def update_image_preview(self, path_str: str):
+        if not _pil_available:
+            self.image_preview_label.setText("Image preview requires Pillow.")
+            return
+
+        if not path_str:
+            self.image_preview_label.setText("Select an image to preview.")
+            self.image_preview_label.setPixmap(QPixmap()) # Clear pixmap
+            return
+
+        path = Path(path_str)
+        if path.is_file():
+            try:
+                pil_img = PILImage.open(path)
+                # Resize for preview
+                pil_img.thumbnail((self.image_preview_label.width() - 10 , self.image_preview_label.height() -10 ), PILImage.Resampling.LANCZOS)
+                qt_image = ImageQt(pil_img)
+                pixmap = QPixmap.fromImage(qt_image)
+                self.image_preview_label.setPixmap(pixmap)
+            except Exception as e:
+                self.image_preview_label.setText(f"Cannot preview image:\n{e}")
+                self.image_preview_label.setPixmap(QPixmap())
+        else:
+            self.image_preview_label.setText("Image file not found.")
+            self.image_preview_label.setPixmap(QPixmap())
+
+
+    def find_similar(self):
+        image_path_str = self.image_path_input.text().strip()
+        if not image_path_str:
+            QMessageBox.warning(self, "Input Error", "Please select an image file.")
+            return
+
+        image_path = Path(image_path_str)
+        if not image_path.is_file():
+            QMessageBox.warning(self, "Input Error", f"Image file not found: {image_path_str}")
+            return
+
+        phash_thresh = self.phash_threshold_spin.value()
+        ahash_thresh = self.ahash_threshold_spin.value()
+        dhash_thresh = self.dhash_threshold_spin.value()
+
+        request_id = str(uuid.uuid4())
+        query_event = FindSimilarImagesQuery(
+            image_path=image_path,
+            phash_threshold=phash_thresh,
+            ahash_threshold=ahash_thresh,
+            dhash_threshold=dhash_thresh,
+            world_name=self.current_world.name,
+            request_id=request_id,
+        )
+
+        self.results_list_widget.clear()
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        try:
+            async def dispatch_query_sync():
+                await self.current_world.dispatch_event(query_event)
+
+            asyncio.run(dispatch_query_sync())
+
+            QApplication.restoreOverrideCursor()
+
+            if query_event.result:
+                if isinstance(query_event.result, list) and query_event.result and "error" in query_event.result[0]:
+                     QMessageBox.warning(self, "Query Error", f"Error from system: {query_event.result[0]['error']}")
+                     self.results_list_widget.addItem(f"Error: {query_event.result[0]['error']}")
+                elif not query_event.result:
+                    self.results_list_widget.addItem("No similar images found.")
+                else:
+                    for match in query_event.result:
+                        # Ensure match is a dict, as per event definition
+                        if isinstance(match, dict):
+                            item_text = (f"ID: {match.get('entity_id', 'N/A')} - "
+                                         f"{match.get('original_filename', 'N/A')} "
+                                         f"(Dist: {match.get('distance', '?')} by {match.get('hash_type', '?')})")
+                            list_item = QListWidgetItem(item_text)
+                            # Store entity_id for double-click action
+                            list_item.setData(Qt.ItemDataRole.UserRole, match.get('entity_id'))
+                            self.results_list_widget.addItem(list_item)
+                        else:
+                             self.results_list_widget.addItem(f"Unexpected result format: {match}")
+            else:
+                self.results_list_widget.addItem("No results or error from similarity query.")
+
+        except Exception as e:
+            QApplication.restoreOverrideCursor()
+            QMessageBox.critical(self, "Find Similar Error", f"An error occurred: {e}")
+            self.results_list_widget.addItem(f"Error: {e}")
+        finally:
+            if QApplication.overrideCursor() is not None:
+                 QApplication.restoreOverrideCursor()
+
+    def view_result_details(self, item: QListWidgetItem):
+        entity_id = item.data(Qt.ItemDataRole.UserRole)
+        if entity_id is None:
+            return # No ID stored
+
+        # Fetch and display components for this entity_id using ComponentViewerDialog
+        # This logic is similar to MainWindow's on_asset_double_clicked
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        components_data_for_dialog: Dict[str, TypingList[Dict[str, Any]]] = {}
+        try:
+            with self.current_world.get_db_session() as session:
+                # Re-importing here to avoid class-level circular dependency if ComponentViewerDialog was in main_window only
+                from dam.models.core.base_component import REGISTERED_COMPONENT_TYPES
+                from dam.services import ecs_service
+
+                entity = ecs_service.get_entity(session, entity_id)
+                if not entity:
+                    QMessageBox.warning(self, "Error", f"Entity ID {entity_id} not found.")
+                    QApplication.restoreOverrideCursor()
+                    return
+
+                for comp_type_name, comp_type_cls in REGISTERED_COMPONENT_TYPES.items():
+                    components = ecs_service.get_components(session, entity_id, comp_type_cls)
+                    component_instances_data = []
+                    if components:
+                        for comp_instance in components:
+                            instance_data = {c.key: getattr(comp_instance, c.key)
+                                             for c in comp_instance.__table__.columns if not c.key.startswith('_')}
+                            component_instances_data.append(instance_data)
+                    components_data_for_dialog[comp_type_name] = component_instances_data
+
+            QApplication.restoreOverrideCursor()
+            viewer_dialog = ComponentViewerDialog(entity_id, components_data_for_dialog, self.current_world.name, self)
+            viewer_dialog.exec()
+
+        except Exception as e:
+            QApplication.restoreOverrideCursor()
+            QMessageBox.critical(self, "Component Fetch Error", f"Error fetching components for Entity ID {entity_id}: {e}")
+        finally:
+            if QApplication.overrideCursor() is not None:
+                 QApplication.restoreOverrideCursor()
+
+
+if __name__ == '__main__':
+    from PyQt6.QtWidgets import QApplication
+    import sys
+
+    class MockWorld:
+        def __init__(self, name="test_world_similar"): self.name = name
+        async def dispatch_event(self, event: FindSimilarImagesQuery):
+            print(f"MockWorld: Event dispatched: {type(event).__name__} for image {event.image_path.name}")
+            await asyncio.sleep(0.2) # Simulate work
+            if "error" in event.image_path.name: # Test error case
+                 event.result = [{"error": "Simulated system error during similarity search."}]
+            elif "empty" in event.image_path.name: # Test no results
+                 event.result = []
+            else:
+                event.result = [
+                    {"entity_id": 101, "original_filename": "similar1.jpg", "distance": 1, "hash_type": "phash"},
+                    {"entity_id": 102, "original_filename": "closematch.png", "distance": 3, "hash_type": "ahash"},
+                ]
+        def get_db_session(self): # For ComponentViewerDialog if used
+            class MockSession:
+                def __enter__(self): return self
+                def __exit__(self,t,v,tb): pass
+                def query(self, *args): return self # Dummy query
+                def filter(self, *args): return self # Dummy filter
+                def all(self): return [] # Dummy all
+            return MockSession()
+
+
+    app = QApplication(sys.argv)
+    world_to_use = MockWorld()
+
+    # Example of trying to load a real world for more integrated testing
+    # try:
+    #     from dam.core import config as app_config
+    #     from dam.core.world import get_world, create_and_register_all_worlds_from_settings
+    #     from dam.core.world_setup import register_core_systems
+    #     worlds = create_and_register_all_worlds_from_settings(app_settings=app_config.settings)
+    #     for w in worlds: register_core_systems(w)
+    #     real_world = get_world(app_config.settings.DEFAULT_WORLD_NAME or (worlds[0].name if worlds else None) )
+    #     if real_world: world_to_use = real_world
+    #     print(f"Using {'REAL' if real_world else 'MOCK'} world: {world_to_use.name}")
+    # except Exception as e:
+    #     print(f"Could not load real world for testing FindSimilarImagesDialog ({e}), using MockWorld.")
+
+
+    dialog = FindSimilarImagesDialog(current_world=world_to_use)
+    dialog.exec()
+    sys.exit(app.exec())

--- a/dam/ui/dialogs/world_operations_dialogs.py
+++ b/dam/ui/dialogs/world_operations_dialogs.py
@@ -1,0 +1,578 @@
+from PyQt6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QLabel, QLineEdit,
+    QFileDialog, QMessageBox, QCheckBox, QApplication, QProgressDialog,
+    QComboBox, QFormLayout # Added QComboBox and QFormLayout
+)
+from PyQt6.QtCore import Qt, QThread, pyqtSignal
+from pathlib import Path
+from typing import Optional, List as TypingList # Added for type hinting
+
+from dam.core.world import World
+from dam.core.config import settings as app_settings # To get list of all configured worlds
+from dam.core.world_setup import get_world # To get world instances by name
+from dam.services import world_service
+
+# --- Worker Thread for Long Operations ---
+class WorldOperationWorker(QThread):
+    finished = pyqtSignal(object, str) # object will be result (e.g., None or error), str is success/error message
+    progress = pyqtSignal(str) # For status updates
+
+    def __init__(self, world: World, operation_type: str, params: dict):
+        super().__init__()
+        self.world = world
+        self.operation_type = operation_type
+        self.params = params
+
+    def run(self):
+        try:
+            if self.operation_type == "export":
+                self.progress.emit(f"Exporting world '{self.world.name}' to {self.params['filepath']}...")
+                world_service.export_ecs_world_to_json(self.world, self.params['filepath'])
+                self.finished.emit(None, f"World '{self.world.name}' exported successfully to {self.params['filepath']}.")
+            elif self.operation_type == "import":
+                self.progress.emit(f"Importing world from {self.params['filepath']} into '{self.world.name}'...")
+                world_service.import_ecs_world_from_json(self.world, self.params['filepath'], self.params['merge'])
+                self.finished.emit(None, f"World data imported successfully into '{self.world.name}' from {self.params['filepath']}.")
+            elif self.operation_type == "merge_db":
+                source_world_name = self.params['source_world_name']
+                target_world_name = self.world.name # Target is the dialog's current_world
+                self.progress.emit(f"Merging world '{source_world_name}' into '{target_world_name}' (DB-to-DB)...")
+                # We need actual World instances. The dialog should pass these.
+                # For now, assuming params contains 'source_world_instance'
+                source_world_instance = self.params['source_world_instance']
+                world_service.merge_ecs_worlds_db_to_db(source_world=source_world_instance, target_world=self.world, strategy="add_new")
+                self.finished.emit(None, f"Successfully merged '{source_world_name}' into '{target_world_name}'.")
+            elif self.operation_type == "split_db":
+                self.progress.emit(f"Splitting world '{self.world.name}'...")
+                # Parameters for split_ecs_world: source_world, target_world_selected, target_world_remaining,
+                # criteria_component_name, criteria_component_attr, criteria_value, criteria_op, delete_from_source
+                count_selected, count_remaining = world_service.split_ecs_world(**self.params)
+                self.finished.emit(None, f"Split complete: {count_selected} entities to selected, {count_remaining} to remaining.")
+            else:
+                self.finished.emit(TypeError(f"Unknown operation type: {self.operation_type}"),
+                                    f"Error: Unknown world operation '{self.operation_type}'.")
+        except Exception as e:
+            self.finished.emit(e, f"Error during {self.operation_type}: {e}")
+
+
+# --- Export World Dialog ---
+class ExportWorldDialog(QDialog):
+    def __init__(self, current_world: World, parent=None):
+        super().__init__(parent)
+        self.current_world = current_world
+        self.setWindowTitle(f"Export World: {current_world.name}")
+        self.setMinimumWidth(400)
+
+        layout = QVBoxLayout(self)
+
+        self.path_input = QLineEdit()
+        self.path_input.setPlaceholderText("Select export file path (.json)")
+        browse_button = QPushButton("Browse...")
+        browse_button.clicked.connect(self.browse_export_path)
+
+        path_layout = QHBoxLayout()
+        path_layout.addWidget(QLabel("Export to:"))
+        path_layout.addWidget(self.path_input)
+        path_layout.addWidget(browse_button)
+        layout.addLayout(path_layout)
+
+        button_layout = QHBoxLayout()
+        self.export_button = QPushButton("Export")
+        self.export_button.clicked.connect(self.start_export)
+        self.cancel_button = QPushButton("Cancel")
+        self.cancel_button.clicked.connect(self.reject)
+        button_layout.addStretch()
+        button_layout.addWidget(self.export_button)
+        button_layout.addWidget(self.cancel_button)
+        layout.addLayout(button_layout)
+
+        self.worker: Optional[WorldOperationWorker] = None
+        self.progress_dialog: Optional[QProgressDialog] = None
+
+    def browse_export_path(self):
+        path_str, _ = QFileDialog.getSaveFileName(self, "Save World Export", "", "JSON Files (*.json)")
+        if path_str:
+            if not path_str.endswith(".json"):
+                path_str += ".json"
+            self.path_input.setText(path_str)
+
+    def start_export(self):
+        filepath_str = self.path_input.text().strip()
+        if not filepath_str:
+            QMessageBox.warning(self, "Input Error", "Please specify an export file path.")
+            return
+
+        filepath = Path(filepath_str)
+        if filepath.is_dir():
+            QMessageBox.warning(self, "Input Error", "Export path cannot be a directory.")
+            return
+        if filepath.exists():
+            reply = QMessageBox.question(self, "Confirm Overwrite",
+                                         f"File '{filepath.name}' already exists. Overwrite?",
+                                         QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                                         QMessageBox.StandardButton.No)
+            if reply == QMessageBox.StandardButton.No:
+                return
+
+        self.export_button.setEnabled(False)
+        self.cancel_button.setText("Working...") # Indicate busy
+
+        self.progress_dialog = QProgressDialog(f"Exporting world '{self.current_world.name}'...",
+                                               "Cancel", 0, 0, self) # 0,0 for indeterminate
+        self.progress_dialog.setWindowTitle("Exporting World")
+        self.progress_dialog.setWindowModality(Qt.WindowModality.WindowModal)
+        self.progress_dialog.canceled.connect(self.cancel_operation)
+
+        self.worker = WorldOperationWorker(self.current_world, "export", {"filepath": filepath})
+        self.worker.finished.connect(self.on_operation_finished)
+        self.worker.progress.connect(lambda msg: self.progress_dialog.setLabelText(msg)) # Update progress text
+        self.worker.start()
+        self.progress_dialog.show()
+
+
+    def on_operation_finished(self, result_exception, message):
+        self.progress_dialog.close()
+        self.export_button.setEnabled(True)
+        self.cancel_button.setText("Cancel")
+
+        if result_exception:
+            QMessageBox.critical(self, "Export Error", message)
+        else:
+            QMessageBox.information(self, "Export Successful", message)
+            super().accept() # Close dialog on success
+
+    def cancel_operation(self):
+        if self.worker and self.worker.isRunning():
+            # QThread.terminate() is risky. Better to have cooperative cancellation if possible.
+            # For now, we'll just inform the user it might take a moment if it's mid-IO.
+            # self.worker.terminate() # Avoid if possible
+            self.worker.requestInterruption() # If worker checks isInterruptionRequested()
+            QMessageBox.information(self, "Export Cancelled", "Export operation cancelled by user. The process might take a moment to fully stop if it was in progress.")
+        self.progress_dialog.close()
+        self.export_button.setEnabled(True)
+        self.cancel_button.setText("Cancel")
+
+
+# --- Import World Dialog ---
+class ImportWorldDialog(QDialog):
+    def __init__(self, current_world: World, parent=None):
+        super().__init__(parent)
+        self.current_world = current_world
+        self.setWindowTitle(f"Import Data into World: {current_world.name}")
+        self.setMinimumWidth(400)
+
+        layout = QVBoxLayout(self)
+
+        self.path_input = QLineEdit()
+        self.path_input.setPlaceholderText("Select import file path (.json)")
+        browse_button = QPushButton("Browse...")
+        browse_button.clicked.connect(self.browse_import_path)
+
+        path_layout = QHBoxLayout()
+        path_layout.addWidget(QLabel("Import from:"))
+        path_layout.addWidget(self.path_input)
+        path_layout.addWidget(browse_button)
+        layout.addLayout(path_layout)
+
+        self.merge_checkbox = QCheckBox("Merge with existing data (if unchecked, target world data might be cleared or conflict)")
+        self.merge_checkbox.setChecked(False) # Default to not merging (safer initial default)
+        # Note: The actual behavior of not merging (overwrite/clear) depends on service implementation.
+        # For now, we assume `merge=False` means it might be destructive or error on conflict.
+        layout.addWidget(self.merge_checkbox)
+
+        button_layout = QHBoxLayout()
+        self.import_button = QPushButton("Import")
+        self.import_button.clicked.connect(self.start_import)
+        self.cancel_button = QPushButton("Cancel")
+        self.cancel_button.clicked.connect(self.reject)
+        button_layout.addStretch()
+        button_layout.addWidget(self.import_button)
+        button_layout.addWidget(self.cancel_button)
+        layout.addLayout(button_layout)
+
+        self.worker: Optional[WorldOperationWorker] = None
+        self.progress_dialog: Optional[QProgressDialog] = None
+
+
+    def browse_import_path(self):
+        path_str, _ = QFileDialog.getOpenFileName(self, "Select World Export File", "", "JSON Files (*.json)")
+        if path_str:
+            self.path_input.setText(path_str)
+
+    def start_import(self):
+        filepath_str = self.path_input.text().strip()
+        if not filepath_str:
+            QMessageBox.warning(self, "Input Error", "Please specify an import file path.")
+            return
+
+        filepath = Path(filepath_str)
+        if not filepath.is_file():
+            QMessageBox.warning(self, "Input Error", f"Import file not found: {filepath_str}")
+            return
+
+        merge_data = self.merge_checkbox.isChecked()
+
+        warning_msg = f"This will import data from '{filepath.name}' into world '{self.current_world.name}'."
+        if not merge_data:
+            warning_msg += "\n\nWithout merging, existing data in the target world might be overwritten or cause conflicts. This operation could be destructive."
+        warning_msg += "\n\nAre you sure you want to proceed?"
+
+        reply = QMessageBox.question(self, "Confirm Import", warning_msg,
+                                     QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                                     QMessageBox.StandardButton.No)
+        if reply == QMessageBox.StandardButton.No:
+            return
+
+        self.import_button.setEnabled(False)
+        self.cancel_button.setText("Working...")
+
+        self.progress_dialog = QProgressDialog(f"Importing data into '{self.current_world.name}'...",
+                                               "Cancel", 0, 0, self)
+        self.progress_dialog.setWindowTitle("Importing World Data")
+        self.progress_dialog.setWindowModality(Qt.WindowModality.WindowModal)
+        self.progress_dialog.canceled.connect(self.cancel_operation)
+
+        self.worker = WorldOperationWorker(self.current_world, "import",
+                                           {"filepath": filepath, "merge": merge_data})
+        self.worker.finished.connect(self.on_operation_finished)
+        self.worker.progress.connect(lambda msg: self.progress_dialog.setLabelText(msg))
+        self.worker.start()
+        self.progress_dialog.show()
+
+
+    def on_operation_finished(self, result_exception, message):
+        self.progress_dialog.close()
+        self.import_button.setEnabled(True)
+        self.cancel_button.setText("Cancel")
+
+        if result_exception:
+            QMessageBox.critical(self, "Import Error", message)
+        else:
+            QMessageBox.information(self, "Import Successful", message)
+            super().accept() # Close dialog on success
+
+    def cancel_operation(self):
+        if self.worker and self.worker.isRunning():
+            self.worker.requestInterruption()
+            QMessageBox.information(self, "Import Cancelled", "Import operation cancelled by user. The process might take a moment to fully stop if it was in progress.")
+        self.progress_dialog.close()
+        self.import_button.setEnabled(True)
+        self.cancel_button.setText("Cancel")
+
+
+if __name__ == '__main__':
+    # Test Script
+    app = QApplication([])
+    # Ensure project modules are discoverable for real world loading, or use mocks.
+    # This might require setting PYTHONPATH or running from project root.
+
+    # Mock or load a real world for testing dialogs
+    test_world_instance = None
+    all_world_names: TypingList[str] = []
+    try:
+        from dam.core.world import create_and_register_all_worlds_from_settings, get_all_registered_worlds
+        from dam.core.world_setup import register_core_systems
+
+        # Initialize worlds (important for get_world to work)
+        # This ensures that the world registry is populated.
+        initialized_worlds = create_and_register_all_worlds_from_settings(app_settings=app_settings)
+        for w_init in initialized_worlds:
+            register_core_systems(w_init) # Register core systems for each world
+
+        # Get all configured world names for dropdowns
+        if app_settings.worlds:
+            all_world_names = [w_config.name for w_config in app_settings.worlds]
+
+        # Try to get the default world or the first one for dialogs that need a 'current_world'
+        if app_settings.DEFAULT_WORLD_NAME:
+            test_world_instance = get_world(app_settings.DEFAULT_WORLD_NAME)
+        elif initialized_worlds:
+            test_world_instance = initialized_worlds[0]
+
+        if not test_world_instance:
+            print("No default or first world found, using a basic MockWorld for some tests.")
+            class MockWorld:
+                def __init__(self, name="mock_world_ops"): self.name = name
+            test_world_instance = MockWorld()
+
+    except Exception as e:
+        print(f"Error loading real worlds for testing ({e}), using a basic MockWorld.")
+        class MockWorld: # Define here if imports fail
+            def __init__(self, name="fallback_mock_ops"): self.name = name
+        test_world_instance = MockWorld()
+        all_world_names = ["mock_world1", "mock_world2", "mock_world3"] # Dummy names for dropdowns
+
+
+    print(f"--- Testing Dialogs (using world: {test_world_instance.name if test_world_instance else 'None'}) ---")
+
+    if QMessageBox.question(None, "Test", "Show Export Dialog?", QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No) == QMessageBox.StandardButton.Yes:
+        if test_world_instance:
+            export_dialog = ExportWorldDialog(current_world=test_world_instance)
+            export_dialog.exec()
+        else: QMessageBox.warning(None, "Error", "No current world to test Export Dialog.")
+
+    if QMessageBox.question(None, "Test", "Show Import Dialog?", QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No) == QMessageBox.StandardButton.Yes:
+        if test_world_instance:
+            import_dialog = ImportWorldDialog(current_world=test_world_instance)
+            import_dialog.exec()
+        else: QMessageBox.warning(None, "Error", "No current world to test Import Dialog.")
+
+    if QMessageBox.question(None, "Test", "Show Merge Worlds Dialog?", QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No) == QMessageBox.StandardButton.Yes:
+        if test_world_instance and all_world_names:
+            # The MergeWorldsDialog determines its own target from its 'current_world'
+            # It needs a list of other worlds to select as source.
+            merge_dialog = MergeWorldsDialog(current_world=test_world_instance, all_world_names=all_world_names)
+            merge_dialog.exec()
+        else: QMessageBox.warning(None, "Error", "Need a current world and list of all worlds for Merge Dialog.")
+
+    if QMessageBox.question(None, "Test", "Show Split World Dialog?", QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No) == QMessageBox.StandardButton.Yes:
+        if test_world_instance and all_world_names:
+             # SplitWorldDialog's 'source_world' is its 'current_world'
+            split_dialog = SplitWorldDialog(source_world=test_world_instance, all_world_names=all_world_names)
+            split_dialog.exec()
+        else: QMessageBox.warning(None, "Error", "Need a source world and list of all worlds for Split Dialog.")
+
+
+    sys.exit(app.exec())
+
+
+# --- Merge Worlds Dialog ---
+class MergeWorldsDialog(QDialog):
+    def __init__(self, current_world: World, all_world_names: TypingList[str], parent=None):
+        super().__init__(parent)
+        self.current_world = current_world # This will be the TARGET world
+        self.all_world_names = [name for name in all_world_names if name != current_world.name] # Exclude self
+
+        self.setWindowTitle(f"Merge another World into: {current_world.name}")
+        self.setMinimumWidth(450)
+        layout = QVBoxLayout(self)
+        form_layout = QFormLayout()
+
+        self.source_world_combo = QComboBox()
+        if not self.all_world_names:
+            self.source_world_combo.addItem("No other worlds available to merge from.")
+            self.source_world_combo.setEnabled(False)
+        else:
+            self.source_world_combo.addItems(self.all_world_names)
+        form_layout.addRow(QLabel(f"Merge From (Source World):"), self.source_world_combo)
+        form_layout.addRow(QLabel(f"Merge Into (Target World):"), QLabel(f"<b>{current_world.name}</b> (current)"))
+
+        layout.addLayout(form_layout)
+        # Strategy note - currently only 'add_new' is supported by backend
+        layout.addWidget(QLabel("<i>Merge strategy: All entities from source will be added as new to target.</i>"))
+
+        button_layout = QHBoxLayout()
+        self.merge_button = QPushButton("Start Merge")
+        self.merge_button.setEnabled(bool(self.all_world_names)) # Disable if no source worlds
+        self.merge_button.clicked.connect(self.start_merge)
+        self.cancel_button = QPushButton("Cancel")
+        self.cancel_button.clicked.connect(self.reject)
+        button_layout.addStretch()
+        button_layout.addWidget(self.merge_button)
+        button_layout.addWidget(self.cancel_button)
+        layout.addLayout(button_layout)
+
+        self.worker: Optional[WorldOperationWorker] = None
+        self.progress_dialog: Optional[QProgressDialog] = None
+
+    def start_merge(self):
+        source_world_name = self.source_world_combo.currentText()
+        if not source_world_name or source_world_name == "No other worlds available to merge from.":
+            QMessageBox.warning(self, "Input Error", "Please select a valid source world.")
+            return
+
+        source_world_instance = get_world(source_world_name)
+        if not source_world_instance:
+            QMessageBox.critical(self, "Error", f"Could not get instance for source world '{source_world_name}'. It might not be initialized correctly.")
+            return
+
+        if source_world_instance.name == self.current_world.name: # Should be prevented by list population
+            QMessageBox.warning(self, "Input Error", "Source and target worlds cannot be the same.")
+            return
+
+        reply = QMessageBox.question(self, "Confirm Merge",
+                                     f"Merge all entities from '{source_world_name}' into '{self.current_world.name}'?\n"
+                                     "This will add all source entities as new entities in the target.",
+                                     QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                                     QMessageBox.StandardButton.No)
+        if reply == QMessageBox.StandardButton.No:
+            return
+
+        self.merge_button.setEnabled(False)
+        self.cancel_button.setText("Working...")
+        self.progress_dialog = QProgressDialog(f"Merging '{source_world_name}' into '{self.current_world.name}'...", "Cancel", 0, 0, self)
+        self.progress_dialog.setWindowTitle("Merging Worlds")
+        self.progress_dialog.setWindowModality(Qt.WindowModality.WindowModal)
+        self.progress_dialog.canceled.connect(self.cancel_operation)
+
+        params = {
+            "source_world_name": source_world_name, # For progress message
+            "source_world_instance": source_world_instance,
+            # Target world is self.current_world, passed to worker's constructor
+        }
+        self.worker = WorldOperationWorker(self.current_world, "merge_db", params)
+        self.worker.finished.connect(self.on_operation_finished)
+        self.worker.progress.connect(lambda msg: self.progress_dialog.setLabelText(msg))
+        self.worker.start()
+        self.progress_dialog.show()
+
+    def on_operation_finished(self, result_exception, message):
+        self.progress_dialog.close()
+        self.merge_button.setEnabled(True)
+        self.cancel_button.setText("Cancel")
+        if result_exception: QMessageBox.critical(self, "Merge Error", message)
+        else: QMessageBox.information(self, "Merge Successful", message); super().accept()
+
+    def cancel_operation(self):
+        if self.worker and self.worker.isRunning(): self.worker.requestInterruption()
+        self.progress_dialog.close()
+        self.merge_button.setEnabled(True)
+        self.cancel_button.setText("Cancel")
+
+
+# --- Split World Dialog ---
+class SplitWorldDialog(QDialog):
+    def __init__(self, source_world: World, all_world_names: TypingList[str], parent=None):
+        super().__init__(parent)
+        self.source_world = source_world # This is the world to split FROM
+        # Worlds for selection as targets (must not be the source world)
+        self.available_target_worlds = [name for name in all_world_names if name != source_world.name]
+
+        self.setWindowTitle(f"Split World: {source_world.name}")
+        self.setMinimumWidth(550) # Wider for more fields
+        layout = QVBoxLayout(self)
+        form_layout = QFormLayout()
+
+        form_layout.addRow(QLabel("<b>Source World:</b>"), QLabel(f"<b>{source_world.name}</b> (entities will be copied from here)"))
+
+        self.target_selected_combo = QComboBox()
+        self.target_remaining_combo = QComboBox()
+        if not self.available_target_worlds or len(self.available_target_worlds) < 2:
+             self.target_selected_combo.addItem("Not enough other worlds available for targets.")
+             self.target_remaining_combo.addItem("Not enough other worlds available for targets.")
+             self.target_selected_combo.setEnabled(False)
+             self.target_remaining_combo.setEnabled(False)
+        else:
+            self.target_selected_combo.addItems(self.available_target_worlds)
+            self.target_remaining_combo.addItems(self.available_target_worlds)
+            # Try to pre-select different targets if possible
+            if len(self.available_target_worlds) >= 2:
+                self.target_remaining_combo.setCurrentIndex(1)
+
+
+        form_layout.addRow(QLabel("Target for Selected Entities:"), self.target_selected_combo)
+        form_layout.addRow(QLabel("Target for Remaining Entities:"), self.target_remaining_combo)
+
+        form_layout.addRow(QLabel("<b>Split Criteria:</b>"))
+        self.component_name_input = QLineEdit()
+        self.component_name_input.setPlaceholderText("e.g., FilePropertiesComponent")
+        form_layout.addRow(QLabel("Component Name:"), self.component_name_input)
+
+        self.attribute_name_input = QLineEdit()
+        self.attribute_name_input.setPlaceholderText("e.g., mime_type")
+        form_layout.addRow(QLabel("Attribute Name:"), self.attribute_name_input)
+
+        self.attribute_value_input = QLineEdit()
+        self.attribute_value_input.setPlaceholderText("e.g., image/jpeg")
+        form_layout.addRow(QLabel("Attribute Value:"), self.attribute_value_input)
+
+        self.operator_combo = QComboBox()
+        self.operator_combo.addItems(['eq', 'ne', 'contains', 'startswith', 'endswith', 'gt', 'lt', 'ge', 'le'])
+        form_layout.addRow(QLabel("Operator:"), self.operator_combo)
+
+        self.delete_from_source_checkbox = QCheckBox("Delete entities from source world after copying")
+        form_layout.addRow(self.delete_from_source_checkbox)
+
+        layout.addLayout(form_layout)
+        button_layout = QHBoxLayout()
+        self.split_button = QPushButton("Start Split")
+        self.split_button.setEnabled(len(self.available_target_worlds) >= 2)
+        self.split_button.clicked.connect(self.start_split)
+        self.cancel_button = QPushButton("Cancel")
+        self.cancel_button.clicked.connect(self.reject)
+        button_layout.addStretch()
+        button_layout.addWidget(self.split_button)
+        button_layout.addWidget(self.cancel_button)
+        layout.addLayout(button_layout)
+
+        self.worker: Optional[WorldOperationWorker] = None
+        self.progress_dialog: Optional[QProgressDialog] = None
+
+    def start_split(self):
+        target_selected_name = self.target_selected_combo.currentText()
+        target_remaining_name = self.target_remaining_combo.currentText()
+
+        if not self.available_target_worlds or len(self.available_target_worlds) < 2: # Should be caught by button enable state
+            QMessageBox.warning(self, "Setup Error", "Not enough distinct target worlds available or selected.")
+            return
+
+        if target_selected_name == target_remaining_name:
+            QMessageBox.warning(self, "Input Error", "Target worlds for selected and remaining entities must be different.")
+            return
+        if target_selected_name == self.source_world.name or target_remaining_name == self.source_world.name:
+             QMessageBox.warning(self, "Input Error", "Target worlds cannot be the same as the source world.")
+             return # Already handled by available_target_worlds logic, but good check
+
+        # Validate criteria inputs
+        criteria_comp_name = self.component_name_input.text().strip()
+        criteria_attr_name = self.attribute_name_input.text().strip()
+        criteria_attr_value = self.attribute_value_input.text().strip() # Value is passed as string
+        if not (criteria_comp_name and criteria_attr_name and criteria_attr_value):
+            QMessageBox.warning(self, "Input Error", "Please fill in all criteria fields (Component Name, Attribute Name, Attribute Value).")
+            return
+
+        target_selected_inst = get_world(target_selected_name)
+        target_remaining_inst = get_world(target_remaining_name)
+
+        if not target_selected_inst or not target_remaining_inst:
+            QMessageBox.critical(self, "Error", "Could not get instances for target worlds. They might not be initialized correctly.")
+            return
+
+        params = {
+            "source_world": self.source_world,
+            "target_world_selected": target_selected_inst,
+            "target_world_remaining": target_remaining_inst,
+            "criteria_component_name": criteria_comp_name,
+            "criteria_component_attr": criteria_attr_name,
+            "criteria_value": criteria_attr_value, # Service layer handles type conversion if needed
+            "criteria_op": self.operator_combo.currentText(),
+            "delete_from_source": self.delete_from_source_checkbox.isChecked()
+        }
+
+        confirm_msg = (f"Split entities from '{self.source_world.name}' into:\n"
+                       f"  - Selected to: '{target_selected_name}'\n"
+                       f"  - Remaining to: '{target_remaining_name}'\n"
+                       f"Based on criteria: {criteria_comp_name}.{criteria_attr_name} {params['criteria_op']} '{criteria_attr_value}'\n")
+        if params['delete_from_source']:
+            confirm_msg += "\nWARNING: Entities will be deleted from the source world after copying!\n"
+        confirm_msg += "\nAre you sure you want to proceed?"
+
+        if QMessageBox.question(self, "Confirm Split", confirm_msg, QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No, QMessageBox.StandardButton.No) == QMessageBox.StandardButton.No:
+            return
+
+        self.split_button.setEnabled(False)
+        self.cancel_button.setText("Working...")
+        self.progress_dialog = QProgressDialog(f"Splitting world '{self.source_world.name}'...", "Cancel", 0, 0, self)
+        self.progress_dialog.setWindowTitle("Splitting World")
+        self.progress_dialog.setWindowModality(Qt.WindowModality.WindowModal)
+        self.progress_dialog.canceled.connect(self.cancel_operation)
+
+        # Worker receives source_world as its 'world' context, other params go into 'params'
+        self.worker = WorldOperationWorker(self.source_world, "split_db", params)
+        self.worker.finished.connect(self.on_operation_finished)
+        self.worker.progress.connect(lambda msg: self.progress_dialog.setLabelText(msg))
+        self.worker.start()
+        self.progress_dialog.show()
+
+    def on_operation_finished(self, result_exception, message):
+        self.progress_dialog.close()
+        self.split_button.setEnabled(True)
+        self.cancel_button.setText("Cancel")
+        if result_exception: QMessageBox.critical(self, "Split Error", message)
+        else: QMessageBox.information(self, "Split Successful", message); super().accept()
+
+    def cancel_operation(self):
+        if self.worker and self.worker.isRunning(): self.worker.requestInterruption()
+        self.progress_dialog.close()
+        self.split_button.setEnabled(True) # Re-enable based on initial logic if needed
+        self.cancel_button.setText("Cancel")

--- a/dam/ui/main_window.py
+++ b/dam/ui/main_window.py
@@ -1,0 +1,549 @@
+import sys
+from PyQt6.QtWidgets import (
+    QApplication,
+    QMainWindow,
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QHBoxLayout,
+    QMessageBox,
+    QLineEdit,
+    QComboBox,
+    QDialog,
+    QTextEdit,
+    QVBoxLayout as QDialogVBoxLayout,
+    QScrollArea,
+    QPushButton as QDialogButton,
+    QFileDialog, # For file/directory selection
+    QCheckBox, # For boolean options
+    QFormLayout, # For dialog forms
+)
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QAction
+
+# Actual imports for fetching data
+from dam.core.world import World
+from dam.services import ecs_service
+from dam.models.properties.file_properties_component import FilePropertiesComponent
+# from dam.models.core.entity import Entity # Not directly needed if using service functions
+
+# Added for type hinting, Optional already imported from typing
+from typing import Optional, Dict, Any, List as TypingList
+
+from dam.models.core.base_component import REGISTERED_COMPONENT_TYPES
+from dam.ui.dialogs.add_asset_dialog import AddAssetDialog
+from dam.ui.dialogs.find_asset_by_hash_dialog import FindAssetByHashDialog
+from dam.ui.dialogs.find_similar_images_dialog import FindSimilarImagesDialog, _pil_available
+from dam.ui.dialogs.world_operations_dialogs import (
+    ExportWorldDialog, ImportWorldDialog, MergeWorldsDialog, SplitWorldDialog
+)
+from dam.core.config import settings as app_settings # For getting all world names
+import json # For pretty printing component data
+
+class ComponentViewerDialog(QDialog):
+    def __init__(self, entity_id: int, components_data: Dict[str, TypingList[Dict[str, Any]]], world_name: str, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle(f"Components for Entity ID: {entity_id} (World: {world_name})")
+        self.setGeometry(200, 200, 700, 500) # Adjusted size
+
+        layout = QDialogVBoxLayout(self) # Use alias for clarity
+
+        self.text_edit = QTextEdit()
+        self.text_edit.setReadOnly(True)
+
+        formatted_text = f"Entity ID: {entity_id}\nWorld: {world_name}\n\nComponents:\n"
+        formatted_text += "="*20 + "\n\n"
+
+        if not components_data:
+            formatted_text += "No components found for this entity."
+        else:
+            for comp_name, comp_list in components_data.items():
+                formatted_text += f"--- {comp_name} ---\n"
+                if not comp_list:
+                    formatted_text += "  (No instances of this component type)\n"
+                else:
+                    for i, comp_data in enumerate(comp_list):
+                        # Pretty print each component's data
+                        try:
+                            # Exclude SQLAlchemy internal state if present
+                            data_to_print = {k: v for k, v in comp_data.items() if not k.startswith('_sa_')}
+                            formatted_text += json.dumps(data_to_print, indent=2, default=str) # default=str for non-serializable
+                        except Exception as e:
+                            formatted_text += f"  Error formatting component: {e}\n"
+                            # Fallback to string representation if JSON fails
+                            formatted_text += str(comp_data)
+                        formatted_text += "\n"
+                        if i < len(comp_list) - 1:
+                             formatted_text += "-\n" # Separator for multiple instances of same component type
+                formatted_text += "\n"
+
+        self.text_edit.setText(formatted_text)
+
+        scroll_area = QScrollArea()
+        scroll_area.setWidgetResizable(True)
+        scroll_area.setWidget(self.text_edit)
+        layout.addWidget(scroll_area)
+
+        close_button = QDialogButton("Close") # Use alias
+        close_button.clicked.connect(self.accept)
+        layout.addWidget(close_button)
+
+        self.setLayout(layout)
+
+
+class MainWindow(QMainWindow):
+    def __init__(self, current_world: Optional[World] = None):
+        super().__init__()
+
+        self.current_world = current_world
+        self.setWindowTitle(f"DAM UI - World: {current_world.name if current_world else 'No World Selected'}")
+        self.setGeometry(100, 100, 800, 600)
+
+        self._create_menus()
+        self._create_status_bar()
+        self._create_central_widget()
+
+        # Store the world instance if needed for data fetching
+        # self.current_world = None # Placeholder, needs to be set, e.g. via CLI or a selector
+
+    def _create_menus(self):
+        menu_bar = self.menuBar()
+
+        # File Menu
+        file_menu = menu_bar.addMenu("&File")
+        add_asset_action = QAction("&Add Asset(s)...", self)
+        add_asset_action.triggered.connect(self.open_add_asset_dialog)
+        file_menu.addAction(add_asset_action)
+        file_menu.addSeparator()
+
+        find_by_hash_action = QAction("Find Asset by &Hash...", self)
+        find_by_hash_action.triggered.connect(self.open_find_asset_by_hash_dialog)
+        file_menu.addAction(find_by_hash_action)
+
+        find_similar_action = QAction("Find &Similar Images...", self)
+        find_similar_action.triggered.connect(self.open_find_similar_images_dialog)
+        file_menu.addAction(find_similar_action)
+
+        file_menu.addSeparator()
+        exit_action = QAction("&Exit", self)
+        exit_action.triggered.connect(self.close)
+        file_menu.addAction(exit_action)
+
+        # Edit Menu (Placeholder)
+        edit_menu = menu_bar.addMenu("&Edit") # Keep reference if items added later
+
+        # View Menu
+        view_menu = menu_bar.addMenu("&View")
+        refresh_action = QAction("&Refresh Asset List", self)
+        refresh_action.triggered.connect(self._clear_filters_and_refresh)
+        view_menu.addAction(refresh_action)
+
+        # Tools Menu
+        tools_menu = menu_bar.addMenu("&Tools")
+        export_world_action = QAction("&Export Current World...", self)
+        export_world_action.triggered.connect(self.open_export_world_dialog)
+        tools_menu.addAction(export_world_action)
+
+        import_world_action = QAction("&Import Data into Current World...", self)
+        import_world_action.triggered.connect(self.open_import_world_dialog)
+        tools_menu.addAction(import_world_action)
+        tools_menu.addSeparator()
+
+        merge_worlds_action = QAction("&Merge Worlds...", self)
+        merge_worlds_action.triggered.connect(self.open_merge_worlds_dialog)
+        tools_menu.addAction(merge_worlds_action)
+
+        split_world_action = QAction("&Split Current World...", self)
+        split_world_action.triggered.connect(self.open_split_world_dialog)
+        tools_menu.addAction(split_world_action)
+        tools_menu.addSeparator()
+
+        setup_db_action = QAction("Setup &Database for Current World...", self)
+        setup_db_action.triggered.connect(self.setup_current_world_db)
+        tools_menu.addAction(setup_db_action)
+
+        # Help Menu (Placeholder)
+        help_menu = menu_bar.addMenu("&Help")
+
+
+    def open_add_asset_dialog(self):
+        if not self.current_world:
+            QMessageBox.warning(self, "No World", "Please select or configure a DAM world first.")
+            return
+
+        dialog = AddAssetDialog(current_world=self.current_world, parent=self)
+        if dialog.exec():
+            self.statusBar().showMessage("Asset ingestion process completed. Refreshing asset list...")
+            self.load_assets()
+        else:
+            self.statusBar().showMessage("Add asset operation cancelled or failed.")
+
+    def open_find_asset_by_hash_dialog(self):
+        if not self.current_world:
+            QMessageBox.warning(self, "No World", "Please select or configure a DAM world first.")
+            return
+
+        dialog = FindAssetByHashDialog(current_world=self.current_world, parent=self)
+        # The dialog itself handles showing results or further dialogs (like ComponentViewer)
+        # so we just need to exec() it.
+        dialog.exec()
+        # Optionally, refresh main list if find operation could alter state, but usually not.
+
+    def open_find_similar_images_dialog(self):
+        if not self.current_world:
+            QMessageBox.warning(self, "No World", "Please select or configure a DAM world first.")
+            return
+
+        if not _pil_available: # Check if Pillow is available for image previews
+             QMessageBox.warning(self, "Dependency Missing",
+                                "Pillow (PIL) is not installed. Image previews will not be available in the find similar images dialog. "
+                                "Please install 'ecs-dam-system[image]' for full functionality.")
+
+        dialog = FindSimilarImagesDialog(current_world=self.current_world, parent=self)
+        dialog.exec()
+
+    def open_export_world_dialog(self):
+        if not self.current_world:
+            QMessageBox.warning(self, "No World", "Please select or configure a DAM world first to export.")
+            return
+        dialog = ExportWorldDialog(current_world=self.current_world, parent=self)
+        dialog.exec()
+        # Status updates are handled by the dialog and its worker thread
+
+    def open_import_world_dialog(self):
+        if not self.current_world:
+            QMessageBox.warning(self, "No World", "Please select or configure a DAM world first to import into.")
+            return
+        dialog = ImportWorldDialog(current_world=self.current_world, parent=self)
+        if dialog.exec(): # Dialog's accept() called on success
+            self.statusBar().showMessage("Import process completed. Refreshing asset list...")
+            self.load_assets() # Refresh list as data might have changed
+        else:
+            self.statusBar().showMessage("Import operation cancelled or failed.")
+
+    def open_merge_worlds_dialog(self):
+        if not self.current_world:
+            QMessageBox.warning(self, "No World", "A current world must be active to serve as the merge target.")
+            return
+        all_world_names = [w.name for w in app_settings.worlds] if app_settings.worlds else []
+        if len(all_world_names) < 2:
+            QMessageBox.information(self, "Not Enough Worlds", "At least two worlds must be configured to perform a merge operation.")
+            return
+
+        dialog = MergeWorldsDialog(current_world=self.current_world, all_world_names=all_world_names, parent=self)
+        if dialog.exec():
+            self.statusBar().showMessage("Merge process completed. Refreshing asset list...")
+            self.load_assets() # Refresh list as target world data changed
+        else:
+            self.statusBar().showMessage("Merge operation cancelled or failed.")
+
+    def open_split_world_dialog(self):
+        if not self.current_world:
+            QMessageBox.warning(self, "No World", "A current world must be active to serve as the split source.")
+            return
+        all_world_names = [w.name for w in app_settings.worlds] if app_settings.worlds else []
+        if len(all_world_names) < 3: # Need source + at least two unique targets
+            QMessageBox.information(self, "Not Enough Worlds",
+                                    "At least three worlds must be configured to perform a split operation (one source, two distinct targets).")
+            return
+
+        dialog = SplitWorldDialog(source_world=self.current_world, all_world_names=all_world_names, parent=self)
+        if dialog.exec():
+            self.statusBar().showMessage("Split process completed. Refreshing asset list...")
+            self.load_assets() # Refresh list as source world data might have changed (if delete option used)
+        else:
+            self.statusBar().showMessage("Split operation cancelled or failed.")
+
+    def setup_current_world_db(self):
+        if not self.current_world:
+            QMessageBox.warning(self, "No World", "No current world is active to set up its database.")
+            return
+
+        reply = QMessageBox.question(self, "Confirm Database Setup",
+                                     f"This will attempt to initialize the database and create tables for world '{self.current_world.name}'.\n"
+                                     "This is typically done once. Proceed?",
+                                     QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                                     QMessageBox.StandardButton.No)
+        if reply == QMessageBox.StandardButton.No:
+            return
+
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        self.statusBar().showMessage(f"Setting up database for world '{self.current_world.name}'...")
+        try:
+            self.current_world.create_db_and_tables()
+            QApplication.restoreOverrideCursor()
+            QMessageBox.information(self, "Database Setup Successful",
+                                    f"Database setup complete for world '{self.current_world.name}'.")
+            self.statusBar().showMessage(f"Database for '{self.current_world.name}' successfully set up.")
+            self.load_assets() # Refresh asset list, in case it was empty due to no tables
+        except Exception as e:
+            QApplication.restoreOverrideCursor()
+            QMessageBox.critical(self, "Database Setup Error",
+                                 f"Error during database setup for '{self.current_world.name}':\n{e}")
+            self.statusBar().showMessage(f"Database setup for '{self.current_world.name}' failed: {e}")
+        finally:
+            if QApplication.overrideCursor() is not None: # Ensure cursor is restored
+                 QApplication.restoreOverrideCursor()
+
+
+    def _create_status_bar(self):
+        self.statusBar().showMessage("Ready")
+
+    def _create_central_widget(self):
+        central_widget = QWidget()
+        main_layout = QVBoxLayout(central_widget)
+
+        # Top bar for controls
+        controls_layout = QHBoxLayout()
+
+        # Search input
+        self.search_input = QLineEdit()
+        self.search_input.setPlaceholderText("Search by filename...")
+        self.search_input.returnPressed.connect(self.load_assets) # Trigger search on Enter
+        controls_layout.addWidget(self.search_input)
+
+        search_button = QPushButton("Search")
+        search_button.clicked.connect(self.load_assets)
+        controls_layout.addWidget(search_button)
+
+        # MIME type filter
+        controls_layout.addWidget(QLabel("Filter by Type:"))
+        self.mime_type_filter = QComboBox()
+        self.mime_type_filter.setFixedWidth(150) # Adjust width as needed
+        self.mime_type_filter.addItem("All Types", "") # User data is empty string for no filter
+        # self.populate_mime_type_filter() # Call this after world is confirmed
+        self.mime_type_filter.currentIndexChanged.connect(self.load_assets)
+        controls_layout.addWidget(self.mime_type_filter)
+
+        self.refresh_button = QPushButton("Refresh All") # Renamed from "Clear Search" for clarity
+        self.refresh_button.clicked.connect(self._clear_filters_and_refresh)
+        controls_layout.addWidget(self.refresh_button)
+
+        controls_layout.addStretch()
+        main_layout.addLayout(controls_layout)
+
+        # Asset list widget
+        self.asset_list_widget = QListWidget()
+        self.asset_list_widget.itemDoubleClicked.connect(self.on_asset_double_clicked)
+        main_layout.addWidget(self.asset_list_widget)
+
+        self.setCentralWidget(central_widget)
+        self.populate_mime_type_filter() # Populate filter once after UI setup
+        self.load_assets() # Initial load
+
+    def _clear_filters_and_refresh(self):
+        self.search_input.clear()
+        self.mime_type_filter.setCurrentIndex(0) # Reset to "All Types"
+        self.load_assets()
+
+    def populate_mime_type_filter(self):
+        self.mime_type_filter.blockSignals(True) # Block signals during population
+        # Store current selection
+        current_filter_value = self.mime_type_filter.currentData()
+
+        self.mime_type_filter.clear()
+        self.mime_type_filter.addItem("All Types", "") # Add default "All Types"
+
+        if self.current_world:
+            try:
+                with self.current_world.get_db_session() as session:
+                    distinct_mime_types = session.query(FilePropertiesComponent.mime_type).\
+                                                filter(FilePropertiesComponent.mime_type.isnot(None)).\
+                                                distinct().order_by(FilePropertiesComponent.mime_type).all()
+                    for (mime_type,) in distinct_mime_types:
+                        if mime_type: # Ensure not empty string if that's possible from DB
+                            self.mime_type_filter.addItem(mime_type, mime_type)
+
+                # Restore previous selection if possible
+                index_to_set = self.mime_type_filter.findData(current_filter_value)
+                if index_to_set != -1:
+                    self.mime_type_filter.setCurrentIndex(index_to_set)
+                else:
+                    self.mime_type_filter.setCurrentIndex(0) # Default to "All Types"
+
+            except Exception as e:
+                print(f"Error populating MIME type filter: {e}") # Log or show error
+                QMessageBox.warning(self, "Filter Error", f"Could not populate MIME type filter: {e}")
+        self.mime_type_filter.blockSignals(False) # Unblock signals
+
+    def load_assets(self):
+        search_term = self.search_input.text().strip().lower()
+        selected_mime_type = self.mime_type_filter.currentData() # Get data (actual MIME type string)
+
+        status_message_parts = ["Loading assets"]
+        if search_term:
+            status_message_parts.append(f"searching for '{search_term}'")
+        if selected_mime_type:
+            status_message_parts.append(f"filtered by type '{selected_mime_type}'")
+
+        self.statusBar().showMessage("... ".join(status_message_parts) + "...")
+        self.asset_list_widget.clear()
+
+        if not self.current_world:
+            self.statusBar().showMessage("Error: No world selected.")
+            QMessageBox.warning(self, "Error", "No DAM world is currently selected. Cannot load assets.")
+            self.asset_list_widget.addItem("No world selected.")
+            return
+
+        try:
+            with self.current_world.get_db_session() as session:
+                query = session.query(FilePropertiesComponent.entity_id, FilePropertiesComponent.original_filename, FilePropertiesComponent.mime_type)
+
+                if search_term:
+                    query = query.filter(FilePropertiesComponent.original_filename.ilike(f"%{search_term}%"))
+
+                if selected_mime_type: # Filter by MIME type if one is selected
+                    query = query.filter(FilePropertiesComponent.mime_type == selected_mime_type)
+
+                assets_found = query.all()
+
+                if not assets_found:
+                    message = "No assets found."
+                    if search_term or selected_mime_type:
+                        message_parts = ["No assets found"]
+                        if search_term: message_parts.append(f"matching '{search_term}'")
+                        if selected_mime_type: message_parts.append(f"of type '{selected_mime_type}'")
+                        message = " ".join(message_parts) + "."
+                    self.asset_list_widget.addItem(message)
+                    self.statusBar().showMessage(message)
+                    return
+
+                for entity_id, original_filename, mime_type_val in assets_found:
+                    display_text = f"ID: {entity_id} - {original_filename} ({mime_type_val or 'N/A'})"
+                    item = QListWidgetItem(display_text)
+                    item.setData(Qt.ItemDataRole.UserRole, entity_id)
+                    self.asset_list_widget.addItem(item)
+
+                num_found = len(assets_found)
+                loaded_message_parts = [f"Loaded {num_found} asset{'s' if num_found != 1 else ''}"]
+                if search_term: loaded_message_parts.append(f"matching '{search_term}'")
+                if selected_mime_type: loaded_message_parts.append(f"of type '{selected_mime_type}'")
+                loaded_message_parts.append(f"from world '{self.current_world.name}'.")
+                self.statusBar().showMessage(" ".join(loaded_message_parts))
+
+        except Exception as e:
+            self.statusBar().showMessage(f"Error loading assets: {e}")
+            QMessageBox.critical(self, "Load Assets Error", f"Could not load assets from world '{self.current_world.name}':\n{e}")
+            # Consider logging the full traceback for debugging
+            # import traceback
+            # print(traceback.format_exc())
+            self.asset_list_widget.addItem(f"Error loading assets: {e}")
+
+
+    def on_asset_double_clicked(self, item: QListWidgetItem):
+        asset_id = item.data(Qt.ItemDataRole.UserRole)
+        if asset_id is None: # Should not happen if data is set correctly
+            QMessageBox.warning(self, "Error", "No asset ID associated with this item.")
+            return
+
+        if not self.current_world:
+            QMessageBox.warning(self, "Error", "No world selected. Cannot view components.")
+            return
+
+        self.statusBar().showMessage(f"Fetching components for Entity ID: {asset_id}...")
+
+        components_data_for_dialog: Dict[str, TypingList[Dict[str, Any]]] = {}
+        try:
+            with self.current_world.get_db_session() as session:
+                entity = ecs_service.get_entity(session, asset_id)
+                if not entity:
+                    QMessageBox.warning(self, "Error", f"Entity ID {asset_id} not found in world '{self.current_world.name}'.")
+                    self.statusBar().showMessage(f"Entity ID {asset_id} not found.")
+                    return
+
+                for comp_type_name, comp_type_cls in REGISTERED_COMPONENT_TYPES.items():
+                    components = ecs_service.get_components(session, asset_id, comp_type_cls)
+                    component_instances_data = []
+                    if components:
+                        for comp_instance in components:
+                            # Convert component instance to a dictionary
+                            # This is a basic conversion; more sophisticated serialization might be needed
+                            # for complex types or relationships within components.
+                            instance_data = {c.key: getattr(comp_instance, c.key)
+                                             for c in comp_instance.__table__.columns
+                                             if not c.key.startswith('_')} # Exclude SQLAlchemy internals
+                            component_instances_data.append(instance_data)
+                    components_data_for_dialog[comp_type_name] = component_instances_data
+
+            if not components_data_for_dialog:
+                 self.statusBar().showMessage(f"No components found for Entity ID: {asset_id}.")
+            else:
+                self.statusBar().showMessage(f"Successfully fetched components for Entity ID: {asset_id}.")
+
+            dialog = ComponentViewerDialog(asset_id, components_data_for_dialog, self.current_world.name, self)
+            dialog.exec()
+
+        except Exception as e:
+            error_msg = f"Error fetching components for Entity ID {asset_id}: {e}"
+            self.statusBar().showMessage(error_msg)
+            QMessageBox.critical(self, "Component Fetch Error", error_msg)
+            # import traceback; print(traceback.format_exc()) # For debugging
+
+
+if __name__ == "__main__":
+    # This part needs to be adjusted if the UI is launched via CLI
+    # The CLI will handle QApplication instance.
+    # For direct execution (testing main_window.py):
+    app = QApplication.instance()
+    if not app:
+        app = QApplication(sys.argv)
+
+    # Here you would ideally get the world instance if needed for the UI
+    # For example, if a default world is configured:
+    # from dam.core.config import settings
+    # from dam.core.world_setup import register_core_systems
+    #
+    # if settings.DEFAULT_WORLD_NAME:
+    #     world_to_use = get_world(settings.DEFAULT_WORLD_NAME)
+    #     if not world_to_use: # If not initialized by CLI context
+    #         # Minimal setup for standalone run - this is tricky and might not fully replicate CLI env
+    #         from dam.core.world import create_and_register_all_worlds_from_settings
+    #         create_and_register_all_worlds_from_settings(app_settings=settings)
+    #         world_to_use = get_world(settings.DEFAULT_WORLD_NAME)
+    #         if world_to_use:
+    #             register_core_systems(world_to_use) # Register systems for this world
+    # else:
+    #     world_to_use = None
+    #
+    # window = MainWindow()
+    # if world_to_use:
+    #     window.current_world = world_to_use # Pass the world to the window
+    #     print(f"Running UI with world: {world_to_use.name}")
+    # else:
+    #     print("Running UI without a pre-selected world (will use dummy data or require selection).")
+
+    # For standalone testing, we might not have a world, or we might try to load a default one.
+    # This part is primarily for when `python dam/ui/main_window.py` is run directly.
+    # The CLI will pass the world instance.
+    active_world = None
+    # Example: try to load default world if running standalone for testing
+    # This is a simplified setup and might need more robust error handling or configuration.
+    # if not active_world: # If not passed by CLI or set above
+    #     try:
+    #         from dam.core import config as app_config
+    #         from dam.core.world import get_world, create_and_register_all_worlds_from_settings
+    #         from dam.core.world_setup import register_core_systems
+    #
+    #         # Ensure worlds are initialized from settings
+    #         initialized_worlds = create_and_register_all_worlds_from_settings(app_settings=app_config.settings)
+    #         for world_instance in initialized_worlds:
+    #             register_core_systems(world_instance)
+    #
+    #         if app_config.settings.DEFAULT_WORLD_NAME:
+    #             active_world = get_world(app_config.settings.DEFAULT_WORLD_NAME)
+    #         elif initialized_worlds:
+    #             active_world = initialized_worlds[0] # Fallback to the first initialized world
+    #
+    #         if active_world:
+    #             print(f"Standalone: Using world '{active_world.name}' for UI.")
+    #         else:
+    #             print("Standalone: No world could be automatically determined. UI may have limited functionality.")
+    #     except Exception as e:
+    #         print(f"Standalone: Error initializing default world: {e}")
+
+    window = MainWindow(current_world=active_world) # Pass active_world (could be None)
+    window.show()
+    sys.exit(app.exec())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ video = [ # For video processing, could include ffmpeg-python if made optional
 audio = [ # For audio processing
     # "mutagen", # Good for audio tags
 ]
+ui = [
+    "PyQt6"
+]
 dev = [ # Example for dev/test dependencies
     "pytest",
     "pytest-cov",


### PR DESCRIPTION
This commit completes the implementation of graphical user interfaces for all major CLI operations within the optional PyQt6 UI.

New UI functionalities added:
- Add Asset(s): Dialog for `add-asset` functionality, including options for no-copy and recursive processing.
- Find Asset by Hash: Dialog for `find-file-by-hash`, allowing direct hash input or calculation from a file, and displaying results using the component viewer.
- Find Similar Images: Dialog for `find-similar-images`, with image preview, threshold inputs, and results display, linking to component viewer.
- World Export/Import: Dialogs for `export-world` and `import-world` operations, running them in a background thread with progress indication.
- World Merge/Split: Dialogs for `merge-worlds-db` and `split-world-db` (advanced operations), allowing selection of worlds and criteria, also with background processing and progress indication.
- Setup Database: Action to initialize the database for the current world (`setup-db`).

Other changes:
- Dialogs are organized into a `dam/ui/dialogs/` sub-package.
- Enhanced `WorldOperationWorker` to handle merge and split operations.
- Integrated all new dialogs and actions into the main window's menu structure.
- Updated `README.md` to reflect the new UI capabilities and project structure.