### PR TITLE
Refactor: Simplify WorldConfig/WorldName DI for systems

### DIFF
--- a/dam/core/events.py
+++ b/dam/core/events.py
@@ -1,6 +1,7 @@
-from dataclasses import dataclass
+import asyncio
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional  # Added Optional, List, Dict
+from typing import Any, Dict, List, Optional  # Added Optional, List, Dict
 
 # Using dataclasses for simplicity, similar to Bevy events.
 
@@ -83,10 +84,10 @@ class FindEntityByHashQuery(BaseEvent):
     hash_value: str
     world_name: str  # Target world for this query
     request_id: str  # Unique ID for this query request
-    hash_type: str = "sha256"  # Moved to the end as it has a default
+    hash_type: str = "sha256"
 
-    # For carrying results if the system modifies the event or posts a new one
-    result: Optional[dict] = None  # field(default=None, init=False) might be better if we don't want it in __init__
+    # For carrying results via an asyncio.Future
+    result_future: Optional[asyncio.Future[Optional[Dict[str, Any]]]] = field(default=None, init=False, repr=False)
 
 
 @dataclass
@@ -100,8 +101,10 @@ class FindSimilarImagesQuery(BaseEvent):
     world_name: str  # Target world for this query
     request_id: str  # Unique ID for this query request
 
-    # For carrying results
-    result: Optional[list] = None  # field(default=None, init=False)
+    # For carrying results via an asyncio.Future
+    result_future: Optional[asyncio.Future[Optional[List[Dict[str, Any]]]]] = field(
+        default=None, init=False, repr=False
+    )
 
 
 # To allow __init__.py in dam/core to import these

--- a/dam/core/system_params.py
+++ b/dam/core/system_params.py
@@ -11,13 +11,11 @@ from dam.models import BaseComponent, Entity
 # Injected by the WorldScheduler.
 WorldSession = Annotated[Session, "WorldSession"]
 
-# Represents the name of the current active world.
-# Injected by the WorldScheduler.
-WorldName = Annotated[str, "WorldName"]
-
-# Represents the configuration object for the current active world.
-# Injected by the WorldScheduler.
-CurrentWorldConfig = Annotated[WorldConfig, "CurrentWorldConfig"]
+# WorldName and CurrentWorldConfig are no longer special DI identities.
+# Systems should inject WorldConfig by its type (it's a resource)
+# and access world_config.name if the name is needed.
+# WorldName = Annotated[str, "WorldName"] # Removed
+# CurrentWorldConfig = Annotated[WorldConfig, "CurrentWorldConfig"] # Removed
 
 # Generic type for resources managed by the ResourceManager.
 # Systems can request a resource by its type.
@@ -84,6 +82,7 @@ class WorldContext:
         self.world_config = world_config
 
     # Note: While WorldContext holds session, world_name, and world_config,
-    # systems should declare these as dependencies via Annotated types (WorldSession,
-    # WorldName, CurrentWorldConfig) rather than directly accessing WorldContext fields.
+    # systems should declare WorldSession via Annotated type for injection.
+    # WorldConfig should be injected by its class type (as a resource).
+    # WorldContext itself can be injected by its class type if needed by advanced systems.
     # This promotes loose coupling and allows the scheduler to manage how these are provided.

--- a/dam/core/world_setup.py
+++ b/dam/core/world_setup.py
@@ -61,6 +61,8 @@ __all__ = ["initialize_world_resources", "register_core_systems"]
 # --- Core System Registration (merged from world_registrar.py) ---
 from typing import TYPE_CHECKING
 
+# Moved these imports to the top of the file, outside of the TYPE_CHECKING block
+# to resolve E402 errors, as they are needed at runtime for registration.
 from dam.core.events import (
     AssetFileIngestionRequested,
     AssetReferenceIngestionRequested,
@@ -80,6 +82,7 @@ from dam.systems.metadata_systems import (
 
 if TYPE_CHECKING:
     # World is already imported at the top of this file for initialize_world_resources
+    # No runtime imports needed here if they are already above.
     pass
 
 

--- a/dam/models/__init__.py
+++ b/dam/models/__init__.py
@@ -3,6 +3,14 @@
 # Ensure all model modules are imported so they register with Base.metadata
 from ..core.components_markers import *  # noqa: F403
 
+# Conceptual components
+# Import the concrete components that are intended for direct use/instantiation
+from .conceptual.comic_book_concept_component import ComicBookConceptComponent
+from .conceptual.comic_book_variant_component import ComicBookVariantComponent
+from .conceptual.entity_tag_link_component import EntityTagLinkComponent  # Added
+from .conceptual.page_link import PageLink
+from .conceptual.tag_concept_component import TagConceptComponent  # Added
+
 # Core model elements
 from .core.base_class import Base
 from .core.base_component import BaseComponent
@@ -27,13 +35,6 @@ from .source_info.original_source_info_component import OriginalSourceInfoCompon
 from .source_info.web_source_component import WebSourceComponent
 from .source_info.website_profile_component import WebsiteProfileComponent
 
-# Conceptual components
-# Import the concrete components that are intended for direct use/instantiation
-from .conceptual.comic_book_concept_component import ComicBookConceptComponent
-from .conceptual.comic_book_variant_component import ComicBookVariantComponent
-from .conceptual.page_link import PageLink
-from .conceptual.tag_concept_component import TagConceptComponent # Added
-from .conceptual.entity_tag_link_component import EntityTagLinkComponent # Added
 # Base abstract conceptual components like BaseConceptualInfoComponent and BaseVariantInfoComponent
 # are typically not re-exported here unless specifically needed for widespread type hinting.
 # Their subclasses (the concrete components above) are what services and systems will primarily work with.
@@ -63,7 +64,7 @@ __all__ = [
     "ComicBookConceptComponent",
     "ComicBookVariantComponent",
     "PageLink",
-    "TagConceptComponent",         # Added
-    "EntityTagLinkComponent",      # Added
+    "TagConceptComponent",  # Added
+    "EntityTagLinkComponent",  # Added
     # Marker components are usually imported via dam.core.components_markers where needed
 ]

--- a/dam/models/conceptual/__init__.py
+++ b/dam/models/conceptual/__init__.py
@@ -1,10 +1,10 @@
 from .base_conceptual_info_component import BaseConceptualInfoComponent
-from .comic_book_concept_component import ComicBookConceptComponent
 from .base_variant_info_component import BaseVariantInfoComponent
+from .comic_book_concept_component import ComicBookConceptComponent
 from .comic_book_variant_component import ComicBookVariantComponent
+from .entity_tag_link_component import EntityTagLinkComponent  # Added import
 from .page_link import PageLink
-from .tag_concept_component import TagConceptComponent # Added import
-from .entity_tag_link_component import EntityTagLinkComponent # Added import
+from .tag_concept_component import TagConceptComponent  # Added import
 
 __all__ = [
     "BaseConceptualInfoComponent",
@@ -12,6 +12,6 @@ __all__ = [
     "BaseVariantInfoComponent",
     "ComicBookVariantComponent",
     "PageLink",
-    "TagConceptComponent", # Added to __all__
-    "EntityTagLinkComponent", # Added to __all__
+    "TagConceptComponent",  # Added to __all__
+    "EntityTagLinkComponent",  # Added to __all__
 ]

--- a/dam/models/conceptual/base_variant_info_component.py
+++ b/dam/models/conceptual/base_variant_info_component.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from sqlalchemy import ForeignKey
-from sqlalchemy.orm import Mapped, mapped_column, relationship, declared_attr # Added declared_attr
+from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship  # Added declared_attr
 
 from ..core.base_component import BaseComponent
 
@@ -38,7 +38,7 @@ class BaseVariantInfoComponent(BaseComponent):
         """Relationship to the parent (owning) Conceptual Asset Entity."""
         return relationship(
             "Entity",
-            foreign_keys=[cls.conceptual_entity_id], # Use cls.conceptual_entity_id
+            foreign_keys=[cls.conceptual_entity_id],  # Use cls.conceptual_entity_id
             # backref="variants_conceptual_links", # Consider if a backref is needed and how it would work with multiple variant types
             repr=False,
         )

--- a/dam/models/conceptual/comic_book_variant_component.py
+++ b/dam/models/conceptual/comic_book_variant_component.py
@@ -16,23 +16,17 @@ class ComicBookVariantComponent(BaseVariantInfoComponent):
     # id, entity_id, conceptual_entity_id, created_at, updated_at are inherited.
 
     language: Mapped[str | None] = mapped_column(
-        String(50),
-        nullable=True,
-        index=True,
-        comment="Language of this comic book variant (e.g., 'en', 'jp')."
+        String(50), nullable=True, index=True, comment="Language of this comic book variant (e.g., 'en', 'jp')."
     )
 
     format: Mapped[str | None] = mapped_column(
-        String(50),
-        nullable=True,
-        index=True,
-        comment="File format of this variant (e.g., 'PDF', 'CBZ', 'ePub')."
+        String(50), nullable=True, index=True, comment="File format of this variant (e.g., 'PDF', 'CBZ', 'ePub')."
     )
 
     scan_quality: Mapped[str | None] = mapped_column(
         String(100),
         nullable=True,
-        comment="Description of scan quality, if applicable (e.g., '300dpi', 'WebRip', 'Archive Grade')."
+        comment="Description of scan quality, if applicable (e.g., '300dpi', 'WebRip', 'Archive Grade').",
     )
 
     is_primary_variant: Mapped[bool] = mapped_column(
@@ -40,13 +34,13 @@ class ComicBookVariantComponent(BaseVariantInfoComponent):
         default=False,
         nullable=False,
         index=True,
-        comment="Indicates if this is the primary or preferred variant for the comic book concept."
+        comment="Indicates if this is the primary or preferred variant for the comic book concept.",
     )
 
     variant_description: Mapped[str | None] = mapped_column(
         String(1024),
         nullable=True,
-        comment="A general description for this variant, e.g., 'Collector's Edition Scan', 'Digital Release'."
+        comment="A general description for this variant, e.g., 'Collector's Edition Scan', 'Digital Release'.",
     )
 
     # Could add other comic variant specific fields:
@@ -65,8 +59,8 @@ class ComicBookVariantComponent(BaseVariantInfoComponent):
             "conceptual_entity_id",
             "language",
             "format",
-            "variant_description", # This might be too specific for a unique constraint
-            name="uq_comic_variant_details_per_concept"
+            "variant_description",  # This might be too specific for a unique constraint
+            name="uq_comic_variant_details_per_concept",
         ),
         # An Entity (file) can only be one specific comic book variant of one comic book concept.
         # This is implicitly handled by BaseVariantInfoComponent having conceptual_entity_id

--- a/dam/models/conceptual/entity_tag_link_component.py
+++ b/dam/models/conceptual/entity_tag_link_component.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import ForeignKey, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from ..core.base_component import BaseComponent # This links an entity to a tag concept
+from ..core.base_component import BaseComponent  # This links an entity to a tag concept
 
 if TYPE_CHECKING:
     from ..core.entity import Entity
@@ -15,6 +15,7 @@ class EntityTagLinkComponent(BaseComponent):
     (an Entity that has a TagConceptComponent, representing the tag definition).
     This component effectively applies a defined tag to an entity, optionally with a value.
     """
+
     __tablename__ = "component_entity_tag_link"
 
     # entity_id is inherited from BaseComponent - this is the ID of the entity being tagged.
@@ -25,21 +26,21 @@ class EntityTagLinkComponent(BaseComponent):
         index=True,
         nullable=False,
         init=False,  # Make this init=False as it's set via the 'tag_concept' relationship
-        comment="The ID of the Entity that has the TagConceptComponent (i.e., the tag definition)."
+        comment="The ID of the Entity that has the TagConceptComponent (i.e., the tag definition).",
     )
 
     tag_value: Mapped[str | None] = mapped_column(
-        String(1024), # Max length for a tag value
+        String(1024),  # Max length for a tag value
         nullable=True,
-        comment="Optional value for this tag application, used if the TagConcept allows values (e.g., for a 'Rating' tag, value could be '5')."
+        comment="Optional value for this tag application, used if the TagConcept allows values (e.g., for a 'Rating' tag, value could be '5').",
     )
 
     # Relationship to the TagConcept's Entity for easier navigation
     tag_concept: Mapped["Entity"] = relationship(
         "Entity",
         foreign_keys=[tag_concept_entity_id],
-        backref="applied_as_tag_links", # Keep simple backref name
-        passive_deletes=True # Instructs SA to not attempt to NULL this FK on delete of parent
+        backref="applied_as_tag_links",  # Keep simple backref name
+        passive_deletes=True,  # Instructs SA to not attempt to NULL this FK on delete of parent
     )
 
     __table_args__ = (
@@ -50,7 +51,7 @@ class EntityTagLinkComponent(BaseComponent):
         # SQLite typically allows multiple NULLs in unique constraints as well.
         # If stricter "apply once if no value" is needed, service layer logic might be required
         # or a more complex constraint / generated column.
-        UniqueConstraint('entity_id', 'tag_concept_entity_id', 'tag_value', name='uq_entity_tag_application'),
+        UniqueConstraint("entity_id", "tag_concept_entity_id", "tag_value", name="uq_entity_tag_application"),
     )
 
     def __repr__(self):

--- a/dam/models/conceptual/page_link.py
+++ b/dam/models/conceptual/page_link.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import ForeignKey, Integer, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from ..core.base_class import Base # Inherit from Base for SQLAlchemy declarative mapping
+from ..core.base_class import Base  # Inherit from Base for SQLAlchemy declarative mapping
 
 if TYPE_CHECKING:
     from ..core.entity import Entity
@@ -16,6 +16,7 @@ class PageLink(Base):
     This table facilitates a many-to-many relationship where an image can be a page
     in multiple owner entities, and an owner entity can have multiple ordered pages.
     """
+
     __tablename__ = "page_links"
 
     owner_entity_id: Mapped[int] = mapped_column(
@@ -23,42 +24,40 @@ class PageLink(Base):
         primary_key=True,
         index=True,
         init=False,  # Explicitly make it not an __init__ arg
-        comment="The ID of the Entity that owns this page list (e.g., an Entity with ComicBookVariantComponent)."
+        comment="The ID of the Entity that owns this page list (e.g., an Entity with ComicBookVariantComponent).",
     )
     page_image_entity_id: Mapped[int] = mapped_column(
         ForeignKey("entities.id", ondelete="CASCADE"),
         primary_key=True,
         index=True,
         init=False,  # Explicitly make it not an __init__ arg
-        comment="The ID of the Entity representing the image for this page."
+        comment="The ID of the Entity representing the image for this page.",
     )
     page_number: Mapped[int] = mapped_column(
         Integer,
         nullable=False,  # This remains an __init__ arg
-        comment="The order of this page within the owner's list (1-based)."
+        comment="The order of this page within the owner's list (1-based).",
     )
 
     # Relationships to the Entity table for easy navigation from a PageLink instance
     owner: Mapped["Entity"] = relationship(
         "Entity",
         foreign_keys=[owner_entity_id],
-        backref="owned_page_links" # Entities will have 'owned_page_links' to access their PageLink entries as owner
+        backref="owned_page_links",  # Entities will have 'owned_page_links' to access their PageLink entries as owner
     )
     page_image: Mapped["Entity"] = relationship(
         "Entity",
         foreign_keys=[page_image_entity_id],
-        backref="image_page_links" # Entities will have 'image_page_links' to access their PageLink entries as page_image
+        backref="image_page_links",  # Entities will have 'image_page_links' to access their PageLink entries as page_image
     )
 
     __table_args__ = (
-        UniqueConstraint('owner_entity_id', 'page_number', name='uq_owner_page_number'),
+        UniqueConstraint("owner_entity_id", "page_number", name="uq_owner_page_number"),
         # An image can appear only once for a given owner. If an image could be page 3 AND page 5
         # for the same owner, this constraint should be removed.
         # For now, assuming an image is used at most once per owner entity's page list.
-        UniqueConstraint('owner_entity_id', 'page_image_entity_id', name='uq_owner_page_image'),
+        UniqueConstraint("owner_entity_id", "page_image_entity_id", name="uq_owner_page_image"),
     )
 
     def __repr__(self):
-        return (
-            f"<PageLink owner_id={self.owner_entity_id} page_id={self.page_image_entity_id} page_num={self.page_number}>"
-        )
+        return f"<PageLink owner_id={self.owner_entity_id} page_id={self.page_image_entity_id} page_num={self.page_number}>"

--- a/dam/models/conceptual/tag_concept_component.py
+++ b/dam/models/conceptual/tag_concept_component.py
@@ -1,7 +1,8 @@
-from sqlalchemy import String, Boolean, UniqueConstraint
+from sqlalchemy import Boolean, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from .base_conceptual_info_component import BaseConceptualInfoComponent
+
 # It might be useful to have an Enum for scope types
 # from enum import Enum
 # class TagScopeType(Enum):
@@ -16,6 +17,7 @@ class TagConceptComponent(BaseConceptualInfoComponent):
     This component is attached to an Entity that represents the tag itself.
     Other entities are then linked to this "Tag Entity" to apply the tag.
     """
+
     __tablename__ = "component_tag_concept"
 
     # id, entity_id, created_at, updated_at are inherited via BaseConceptualInfoComponent
@@ -24,29 +26,27 @@ class TagConceptComponent(BaseConceptualInfoComponent):
         String(255),
         nullable=False,
         index=True,
-        comment="The unique name of the tag (e.g., 'Sci-Fi', 'Needs Review', 'Artist:JohnDoe')."
+        comment="The unique name of the tag (e.g., 'Sci-Fi', 'Needs Review', 'Artist:JohnDoe').",
     )
 
     # For simplicity, using strings for scope_type. An Enum could be used for stricter validation.
     tag_scope_type: Mapped[str] = mapped_column(
         String(50),
         nullable=False,
-        default="GLOBAL", # Default to global scope
+        default="GLOBAL",  # Default to global scope
         index=True,
-        comment="Defines the scope of the tag (e.g., 'GLOBAL', 'COMPONENT_CLASS_REQUIRED', 'CONCEPTUAL_ASSET_LOCAL')."
+        comment="Defines the scope of the tag (e.g., 'GLOBAL', 'COMPONENT_CLASS_REQUIRED', 'CONCEPTUAL_ASSET_LOCAL').",
     )
 
     tag_scope_detail: Mapped[str | None] = mapped_column(
         String(1024),
         nullable=True,
         comment="Details for the scope, e.g., component class name if scope_type is 'COMPONENT_CLASS_REQUIRED', "
-                "or an Entity ID if scope_type is 'CONCEPTUAL_ASSET_LOCAL'."
+        "or an Entity ID if scope_type is 'CONCEPTUAL_ASSET_LOCAL'.",
     )
 
     tag_description: Mapped[str | None] = mapped_column(
-        String(2048),
-        nullable=True,
-        comment="A description of what this tag represents or how it should be used."
+        String(2048), nullable=True, comment="A description of what this tag represents or how it should be used."
     )
 
     allow_values: Mapped[bool] = mapped_column(
@@ -54,11 +54,11 @@ class TagConceptComponent(BaseConceptualInfoComponent):
         default=False,
         nullable=False,
         comment="If True, this tag can be applied with an associated value (e.g., Tag 'Rating', Value '5 Stars'). "
-                "If False, it's a simple label tag."
+        "If False, it's a simple label tag.",
     )
 
     __table_args__ = (
-        UniqueConstraint('tag_name', name='uq_tag_concept_name'),
+        UniqueConstraint("tag_name", name="uq_tag_concept_name"),
         # If tag names should be unique only within a certain scope (e.g. different users can have same tag name),
         # this constraint would need to be more complex or handled at service layer.
         # For now, assuming tag_name is globally unique for simplicity of definition.

--- a/dam/services/__init__.py
+++ b/dam/services/__init__.py
@@ -1,36 +1,36 @@
 # This file makes the 'services' directory a Python package.
 
 from . import ecs_service, file_operations, world_service
-from .ecs_service import (
-    add_component_to_entity,
-    create_entity,
-    delete_entity,
-    get_component,
-    get_components,
-    get_entity,
-    remove_component,
-    find_entities_with_components, # Exposing more ecs_service functions
-    get_components_by_value,
-    find_entity_by_content_hash,
-    find_entities_by_component_attribute_value,
-)
 
 # Import functions from the new comic book service
 from .comic_book_service import (
     create_comic_book_concept,
-    link_comic_variant_to_concept,
-    get_variants_for_comic_concept,
-    get_comic_concept_for_variant,
     find_comic_book_concepts,
-    set_primary_comic_variant,
+    get_comic_concept_for_variant,
     get_primary_variant_for_comic_concept,
+    get_variants_for_comic_concept,
+    link_comic_variant_to_concept,
+    set_primary_comic_variant,
     unlink_comic_variant,
+)
+from .ecs_service import (
+    add_component_to_entity,
+    create_entity,
+    delete_entity,
+    find_entities_by_component_attribute_value,
+    find_entities_with_components,  # Exposing more ecs_service functions
+    find_entity_by_content_hash,
+    get_component,
+    get_components,
+    get_components_by_value,
+    get_entity,
+    remove_component,
 )
 
 __all__ = [
     "file_operations",
-    "ecs_service", # Module itself
-    "world_service", # Module itself
+    "ecs_service",  # Module itself
+    "world_service",  # Module itself
     # Functions from ecs_service
     "add_component_to_entity",
     "create_entity",
@@ -56,31 +56,33 @@ __all__ = [
 ]
 
 # Import functions from the new tag service
-from . import tag_service # Import the module first
+from . import tag_service  # noqa: F401 # Import the module first, allow export via __all__
 from .tag_service import (
-    create_tag_concept,
-    get_tag_concept_by_name,
-    get_tag_concept_by_id,
-    find_tag_concepts,
-    update_tag_concept,
-    delete_tag_concept,
     apply_tag_to_entity,
-    remove_tag_from_entity,
-    get_tags_for_entity,
+    create_tag_concept,
+    delete_tag_concept,
+    find_tag_concepts,
     get_entities_for_tag,
+    get_tag_concept_by_id,
+    get_tag_concept_by_name,
+    get_tags_for_entity,
+    remove_tag_from_entity,
+    update_tag_concept,
 )
 
 # Add new service module and its functions to __all__
-__all__.extend([
-    "tag_service", # Module itself
-    "create_tag_concept",
-    "get_tag_concept_by_name",
-    "get_tag_concept_by_id",
-    "find_tag_concepts",
-    "update_tag_concept",
-    "delete_tag_concept",
-    "apply_tag_to_entity",
-    "remove_tag_from_entity",
-    "get_tags_for_entity",
-    "get_entities_for_tag",
-])
+__all__.extend(
+    [
+        "tag_service",  # Module itself
+        "create_tag_concept",
+        "get_tag_concept_by_name",
+        "get_tag_concept_by_id",
+        "find_tag_concepts",
+        "update_tag_concept",
+        "delete_tag_concept",
+        "apply_tag_to_entity",
+        "remove_tag_from_entity",
+        "get_tags_for_entity",
+        "get_entities_for_tag",
+    ]
+)

--- a/dam/services/tag_service.py
+++ b/dam/services/tag_service.py
@@ -1,28 +1,26 @@
+import inspect
 import logging
 from typing import List, Optional, Tuple, Type
 
-from sqlalchemy.orm import Session
-from sqlalchemy import select, delete
+from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
 
-from dam.models.core.entity import Entity
-from dam.models.core.base_component import BaseComponent
 from dam.models.conceptual import (
-    TagConceptComponent,
-    EntityTagLinkComponent,
-    ComicBookConceptComponent,
-    ComicBookVariantComponent,
     BaseConceptualInfoComponent,
-    BaseVariantInfoComponent
+    BaseVariantInfoComponent,
+    ComicBookConceptComponent,
+    EntityTagLinkComponent,
+    TagConceptComponent,
 )
-from dam.models.core.base_component import REGISTERED_COMPONENT_TYPES
-import inspect
-
+from dam.models.core.base_component import REGISTERED_COMPONENT_TYPES, BaseComponent
+from dam.models.core.entity import Entity
 from dam.services import ecs_service
 
 logger = logging.getLogger(__name__)
 
 # --- Tag Definition Functions ---
+
 
 def create_tag_concept(
     session: Session,
@@ -30,7 +28,7 @@ def create_tag_concept(
     scope_type: str,
     scope_detail: Optional[str] = None,
     description: Optional[str] = None,
-    allow_values: bool = False
+    allow_values: bool = False,
 ) -> Optional[Entity]:
     if not tag_name:
         raise ValueError("Tag name cannot be empty.")
@@ -49,7 +47,7 @@ def create_tag_concept(
         tag_scope_type=scope_type.upper(),
         tag_scope_detail=scope_detail,
         tag_description=description,
-        allow_values=allow_values
+        allow_values=allow_values,
     )
     session.add(tag_concept_comp)
     try:
@@ -58,8 +56,11 @@ def create_tag_concept(
         return tag_concept_entity
     except IntegrityError:
         session.rollback()
-        logger.error(f"Failed to create TagConcept '{tag_name}' due to unique constraint violation (name likely exists).")
+        logger.error(
+            f"Failed to create TagConcept '{tag_name}' due to unique constraint violation (name likely exists)."
+        )
         return None
+
 
 def get_tag_concept_by_name(session: Session, name: str) -> Optional[Entity]:
     stmt = (
@@ -69,16 +70,16 @@ def get_tag_concept_by_name(session: Session, name: str) -> Optional[Entity]:
     )
     return session.execute(stmt).scalar_one_or_none()
 
+
 def get_tag_concept_by_id(session: Session, tag_concept_entity_id: int) -> Optional[Entity]:
     tag_concept_entity = ecs_service.get_entity(session, tag_concept_entity_id)
     if tag_concept_entity and ecs_service.get_component(session, tag_concept_entity_id, TagConceptComponent):
         return tag_concept_entity
     return None
 
+
 def find_tag_concepts(
-    session: Session,
-    query_name: Optional[str] = None,
-    scope_type: Optional[str] = None
+    session: Session, query_name: Optional[str] = None, scope_type: Optional[str] = None
 ) -> List[Entity]:
     stmt = select(Entity).join(TagConceptComponent, Entity.id == TagConceptComponent.entity_id)
     if query_name:
@@ -97,7 +98,7 @@ def update_tag_concept(
     scope_type: Optional[str] = None,
     scope_detail: Optional[str] = None,
     description: Optional[str] = None,
-    allow_values: Optional[bool] = None
+    allow_values: Optional[bool] = None,
 ) -> Optional[TagConceptComponent]:
     tag_concept_comp = ecs_service.get_component(session, tag_concept_entity_id, TagConceptComponent)
     if not tag_concept_comp:
@@ -108,7 +109,9 @@ def update_tag_concept(
     if name is not None and tag_concept_comp.tag_name != name:
         existing_tag = get_tag_concept_by_name(session, name)
         if existing_tag and existing_tag.id != tag_concept_entity_id:
-            logger.error(f"Cannot update tag name to '{name}' as it already exists for TagConcept ID {existing_tag.id}.")
+            logger.error(
+                f"Cannot update tag name to '{name}' as it already exists for TagConcept ID {existing_tag.id}."
+            )
             return None
         tag_concept_comp.tag_name = name
         updated = True
@@ -143,7 +146,9 @@ def update_tag_concept(
             logger.info(f"Updated TagConceptComponent for Entity ID {tag_concept_entity_id}.")
         except IntegrityError:
             session.rollback()
-            logger.error(f"Failed to update TagConcept '{tag_concept_comp.tag_name}' due to unique constraint violation (name likely exists).")
+            logger.error(
+                f"Failed to update TagConcept '{tag_concept_comp.tag_name}' due to unique constraint violation (name likely exists)."
+            )
             return None
     return tag_concept_comp
 
@@ -162,11 +167,8 @@ def delete_tag_concept(session: Session, tag_concept_entity_id: int) -> bool:
 
 # --- Tag Application Functions ---
 
-def _is_scope_valid(
-    session: Session,
-    entity_id_to_tag: int,
-    tag_concept_comp: TagConceptComponent
-) -> bool:
+
+def _is_scope_valid(session: Session, entity_id_to_tag: int, tag_concept_comp: TagConceptComponent) -> bool:
     # print(f"DEBUG: _is_scope_valid called for entity {entity_id_to_tag}, tag '{tag_concept_comp.tag_name}'")
     # print(f"DEBUG: REGISTERED_COMPONENT_TYPES at start of _is_scope_valid: {[c.__name__ for c in REGISTERED_COMPONENT_TYPES]}")
 
@@ -178,7 +180,9 @@ def _is_scope_valid(
 
     if scope_type == "COMPONENT_CLASS_REQUIRED":
         if not scope_detail:
-            logger.error(f"TagConcept '{tag_concept_comp.tag_name}' (ID: {tag_concept_comp.entity_id}) has scope COMPONENT_CLASS_REQUIRED but no scope_detail (component class name).")
+            logger.error(
+                f"TagConcept '{tag_concept_comp.tag_name}' (ID: {tag_concept_comp.entity_id}) has scope COMPONENT_CLASS_REQUIRED but no scope_detail (component class name)."
+            )
             return False
 
         required_class: Optional[Type[BaseComponent]] = None
@@ -188,22 +192,30 @@ def _is_scope_valid(
                 break
 
         if not required_class:
-            logger.error(f"Scope validation failed: Component class '{scope_detail}' for tag '{tag_concept_comp.tag_name}' is not a registered component type.")
+            logger.error(
+                f"Scope validation failed: Component class '{scope_detail}' for tag '{tag_concept_comp.tag_name}' is not a registered component type."
+            )
             return False
 
         if not ecs_service.get_component(session, entity_id_to_tag, required_class):
-            logger.warning(f"Scope validation failed: Entity {entity_id_to_tag} does not have required component '{scope_detail}' for tag '{tag_concept_comp.tag_name}'.")
+            logger.warning(
+                f"Scope validation failed: Entity {entity_id_to_tag} does not have required component '{scope_detail}' for tag '{tag_concept_comp.tag_name}'."
+            )
             return False
         return True
 
     if scope_type == "CONCEPTUAL_ASSET_LOCAL":
         if not scope_detail:
-            logger.error(f"TagConcept '{tag_concept_comp.tag_name}' (ID: {tag_concept_comp.entity_id}) has scope CONCEPTUAL_ASSET_LOCAL but no scope_detail (conceptual asset entity ID).")
+            logger.error(
+                f"TagConcept '{tag_concept_comp.tag_name}' (ID: {tag_concept_comp.entity_id}) has scope CONCEPTUAL_ASSET_LOCAL but no scope_detail (conceptual asset entity ID)."
+            )
             return False
         try:
             conceptual_asset_entity_id_for_scope = int(scope_detail)
         except ValueError:
-            logger.error(f"Invalid scope_detail '{scope_detail}' for CONCEPTUAL_ASSET_LOCAL scope of tag '{tag_concept_comp.tag_name}'. Expected integer Entity ID.")
+            logger.error(
+                f"Invalid scope_detail '{scope_detail}' for CONCEPTUAL_ASSET_LOCAL scope of tag '{tag_concept_comp.tag_name}'. Expected integer Entity ID."
+            )
             return False
 
         scope_owner_is_conceptual_asset = False
@@ -211,15 +223,19 @@ def _is_scope_valid(
             scope_owner_is_conceptual_asset = True
         else:
             for comp_type_check in REGISTERED_COMPONENT_TYPES:
-                if inspect.isclass(comp_type_check) and \
-                   issubclass(comp_type_check, BaseConceptualInfoComponent) and \
-                   not comp_type_check.__dict__.get('__abstract__', False): # Use __dict__.get for direct check
+                if (
+                    inspect.isclass(comp_type_check)
+                    and issubclass(comp_type_check, BaseConceptualInfoComponent)
+                    and not comp_type_check.__dict__.get("__abstract__", False)
+                ):  # Use __dict__.get for direct check
                     if ecs_service.get_component(session, conceptual_asset_entity_id_for_scope, comp_type_check):
                         scope_owner_is_conceptual_asset = True
                         break
 
         if not scope_owner_is_conceptual_asset:
-            logger.error(f"Scope detail ID {conceptual_asset_entity_id_for_scope} for tag '{tag_concept_comp.tag_name}' (scope type CONCEPTUAL_ASSET_LOCAL) does not refer to a valid conceptual asset entity.")
+            logger.error(
+                f"Scope detail ID {conceptual_asset_entity_id_for_scope} for tag '{tag_concept_comp.tag_name}' (scope type CONCEPTUAL_ASSET_LOCAL) does not refer to a valid conceptual asset entity."
+            )
             return False
 
         if entity_id_to_tag == conceptual_asset_entity_id_for_scope:
@@ -230,12 +246,12 @@ def _is_scope_valid(
                 is_class = inspect.isclass(comp_type_check)
                 is_variant_subclass = issubclass(comp_type_check, BaseVariantInfoComponent) if is_class else False
                 # Correctly check if the class itself is concrete (not inheriting __abstract__ from parent)
-                is_actually_concrete = not comp_type_check.__dict__.get('__abstract__', False) if is_class else False
+                is_actually_concrete = not comp_type_check.__dict__.get("__abstract__", False) if is_class else False
 
                 if is_class and is_variant_subclass and is_actually_concrete:
                     variant_comp = ecs_service.get_component(session, entity_id_to_tag, comp_type_check)
                     if variant_comp:
-                        if hasattr(variant_comp, 'conceptual_entity_id'):
+                        if hasattr(variant_comp, "conceptual_entity_id"):
                             actual_conceptual_id = variant_comp.conceptual_entity_id
                             if actual_conceptual_id == conceptual_asset_entity_id_for_scope:
                                 is_valid_variant = True
@@ -244,18 +260,19 @@ def _is_scope_valid(
             if is_valid_variant:
                 return True
 
-        logger.warning(f"Scope validation failed: Entity {entity_id_to_tag} is not the specified conceptual asset {conceptual_asset_entity_id_for_scope} nor its variant for tag '{tag_concept_comp.tag_name}'.")
+        logger.warning(
+            f"Scope validation failed: Entity {entity_id_to_tag} is not the specified conceptual asset {conceptual_asset_entity_id_for_scope} nor its variant for tag '{tag_concept_comp.tag_name}'."
+        )
         return False
 
-    logger.warning(f"Unknown tag_scope_type '{scope_type}' for tag '{tag_concept_comp.tag_name}'. Denying application by default for unknown scopes.")
+    logger.warning(
+        f"Unknown tag_scope_type '{scope_type}' for tag '{tag_concept_comp.tag_name}'. Denying application by default for unknown scopes."
+    )
     return False
 
 
 def apply_tag_to_entity(
-    session: Session,
-    entity_id_to_tag: int,
-    tag_concept_entity_id: int,
-    value: Optional[str] = None
+    session: Session, entity_id_to_tag: int, tag_concept_entity_id: int, value: Optional[str] = None
 ) -> Optional[EntityTagLinkComponent]:
     target_entity = ecs_service.get_entity(session, entity_id_to_tag)
     if not target_entity:
@@ -276,34 +293,38 @@ def apply_tag_to_entity(
         return None
 
     if not tag_concept_comp.allow_values and value is not None:
-        logger.warning(f"TagConcept '{tag_concept_comp.tag_name}' (ID: {tag_concept_entity_id}) does not allow values, but value '{value}' provided. Value will be ignored.")
+        logger.warning(
+            f"TagConcept '{tag_concept_comp.tag_name}' (ID: {tag_concept_entity_id}) does not allow values, but value '{value}' provided. Value will be ignored."
+        )
         value = None
 
     existing_link_stmt = select(EntityTagLinkComponent).where(
         EntityTagLinkComponent.entity_id == entity_id_to_tag,
         EntityTagLinkComponent.tag_concept_entity_id == tag_concept_entity_id,
-        EntityTagLinkComponent.tag_value == value
+        EntityTagLinkComponent.tag_value == value,
     )
     existing_link = session.execute(existing_link_stmt).scalar_one_or_none()
 
     if existing_link:
-         logger.warning(f"Tag '{tag_concept_comp.tag_name}' with value '{value}' already applied to Entity {entity_id_to_tag}. Not applying again.")
-         return None
+        logger.warning(
+            f"Tag '{tag_concept_comp.tag_name}' with value '{value}' already applied to Entity {entity_id_to_tag}. Not applying again."
+        )
+        return None
 
-    link_comp = EntityTagLinkComponent(
-        entity=target_entity,
-        tag_concept=tag_concept_entity,
-        tag_value=value
-    )
+    link_comp = EntityTagLinkComponent(entity=target_entity, tag_concept=tag_concept_entity, tag_value=value)
 
     try:
         session.add(link_comp)
         session.flush()
-        logger.info(f"Applied tag '{tag_concept_comp.tag_name}' (Concept ID: {tag_concept_entity_id}) to Entity ID {entity_id_to_tag} with value '{value}'.")
+        logger.info(
+            f"Applied tag '{tag_concept_comp.tag_name}' (Concept ID: {tag_concept_entity_id}) to Entity ID {entity_id_to_tag} with value '{value}'."
+        )
         return link_comp
     except IntegrityError:
         session.rollback()
-        logger.error(f"Failed to apply tag '{tag_concept_comp.tag_name}' to Entity {entity_id_to_tag} (value: '{value}'). Likely duplicate application (this should have been caught by pre-check).")
+        logger.error(
+            f"Failed to apply tag '{tag_concept_comp.tag_name}' to Entity {entity_id_to_tag} (value: '{value}'). Likely duplicate application (this should have been caught by pre-check)."
+        )
         return None
     except Exception as e:
         session.rollback()
@@ -312,30 +333,30 @@ def apply_tag_to_entity(
 
 
 def remove_tag_from_entity(
-    session: Session,
-    entity_id_tagged: int,
-    tag_concept_entity_id: int,
-    value: Optional[str] = None
+    session: Session, entity_id_tagged: int, tag_concept_entity_id: int, value: Optional[str] = None
 ) -> bool:
     stmt = select(EntityTagLinkComponent).where(
         EntityTagLinkComponent.entity_id == entity_id_tagged,
         EntityTagLinkComponent.tag_concept_entity_id == tag_concept_entity_id,
-        EntityTagLinkComponent.tag_value == value
+        EntityTagLinkComponent.tag_value == value,
     )
     link_comp_to_delete = session.execute(stmt).scalar_one_or_none()
 
     if link_comp_to_delete:
         session.delete(link_comp_to_delete)
-        logger.info(f"Removed tag (Concept ID: {tag_concept_entity_id}, Value: '{value}') from Entity ID {entity_id_tagged}.")
+        logger.info(
+            f"Removed tag (Concept ID: {tag_concept_entity_id}, Value: '{value}') from Entity ID {entity_id_tagged}."
+        )
         return True
-    logger.warning(f"Tag application (Concept ID: {tag_concept_entity_id}, Value: '{value}') not found on Entity ID {entity_id_tagged}.")
+    logger.warning(
+        f"Tag application (Concept ID: {tag_concept_entity_id}, Value: '{value}') not found on Entity ID {entity_id_tagged}."
+    )
     return False
 
 
 def get_tags_for_entity(session: Session, entity_id_tagged: int) -> List[Tuple[Entity, Optional[str]]]:
-    stmt = (
-        select(EntityTagLinkComponent.tag_concept_entity_id, EntityTagLinkComponent.tag_value)
-        .where(EntityTagLinkComponent.entity_id == entity_id_tagged)
+    stmt = select(EntityTagLinkComponent.tag_concept_entity_id, EntityTagLinkComponent.tag_value).where(
+        EntityTagLinkComponent.entity_id == entity_id_tagged
     )
     results = session.execute(stmt).all()
 
@@ -351,7 +372,7 @@ def get_entities_for_tag(
     session: Session,
     tag_concept_entity_id: int,
     value_filter: Optional[str] = None,
-    filter_by_value_presence: Optional[bool] = None
+    filter_by_value_presence: Optional[bool] = None,
 ) -> List[Entity]:
     stmt = (
         select(Entity)

--- a/dam/systems/metadata_systems.py
+++ b/dam/systems/metadata_systems.py
@@ -13,11 +13,9 @@ from pathlib import Path
 from typing import Annotated, Any, List  # Added Dict
 
 from dam.core.components_markers import NeedsMetadataExtractionComponent
+from dam.core.config import WorldConfig  # Import WorldConfig directly
 from dam.core.stages import SystemStage
-from dam.core.system_params import (
-    CurrentWorldConfig,
-    WorldSession,
-)
+from dam.core.system_params import WorldSession  # CurrentWorldConfig removed
 from dam.core.systems import system
 from dam.models import (
     AudioPropertiesComponent,
@@ -90,7 +88,7 @@ async def _extract_metadata_with_hachoir_sync(filepath_on_disk: Path) -> Any | N
 @system(stage=SystemStage.METADATA_EXTRACTION)
 async def extract_metadata_on_asset_ingested(
     session: WorldSession,
-    world_config: CurrentWorldConfig,
+    world_config: WorldConfig,  # Changed from CurrentWorldConfig
     entities_to_process: Annotated[List[Entity], "MarkedEntityList", NeedsMetadataExtractionComponent],
 ):
     if not createParser or not extractMetadata:

--- a/tests/test_tag_service.py
+++ b/tests/test_tag_service.py
@@ -1,32 +1,28 @@
 import pytest
 from sqlalchemy.orm import Session
-from sqlalchemy.exc import IntegrityError
 
-from dam.models.core.entity import Entity
 from dam.models.conceptual import (
-    TagConceptComponent,
+    ComicBookVariantComponent,  # For testing scope
     EntityTagLinkComponent,
-    ComicBookConceptComponent, # For testing scope
-    ComicBookVariantComponent  # For testing scope
+    TagConceptComponent,
 )
+from dam.models.core.entity import Entity
+from dam.services import comic_book_service as cbs
 from dam.services import ecs_service
 from dam.services import tag_service as ts
-from dam.services import comic_book_service as cbs
-
 
 # --- Test Data Fixtures ---
+
 
 @pytest.fixture
 def global_tag_concept(db_session: Session) -> Entity:
     tag_entity = ts.create_tag_concept(
-        db_session,
-        tag_name="GlobalTestTag",
-        scope_type="GLOBAL",
-        description="A test tag applicable anywhere."
+        db_session, tag_name="GlobalTestTag", scope_type="GLOBAL", description="A test tag applicable anywhere."
     )
     db_session.commit()
     assert tag_entity is not None
     return tag_entity
+
 
 @pytest.fixture
 def component_scoped_tag_concept(db_session: Session) -> Entity:
@@ -36,11 +32,12 @@ def component_scoped_tag_concept(db_session: Session) -> Entity:
         tag_name="ComicConceptOnlyTag",
         scope_type="COMPONENT_CLASS_REQUIRED",
         scope_detail="ComicBookConceptComponent",
-        description="A tag for comic book concepts only."
+        description="A tag for comic book concepts only.",
     )
     db_session.commit()
     assert tag_entity is not None
     return tag_entity
+
 
 @pytest.fixture
 def local_scoped_tag_concept_for_comic1(db_session: Session, comic_concept1: Entity) -> Entity:
@@ -50,11 +47,12 @@ def local_scoped_tag_concept_for_comic1(db_session: Session, comic_concept1: Ent
         tag_name="LocalTagForComic1",
         scope_type="CONCEPTUAL_ASSET_LOCAL",
         scope_detail=str(comic_concept1.id),
-        description="A local tag for Comic 1 and its variants."
+        description="A local tag for Comic 1 and its variants.",
     )
     db_session.commit()
     assert tag_entity is not None
     return tag_entity
+
 
 @pytest.fixture
 def comic_concept1(db_session: Session) -> Entity:
@@ -62,6 +60,7 @@ def comic_concept1(db_session: Session) -> Entity:
     db_session.commit()
     assert concept is not None
     return concept
+
 
 @pytest.fixture
 def comic_variant1_of_concept1(db_session: Session, comic_concept1: Entity) -> Entity:
@@ -71,16 +70,18 @@ def comic_variant1_of_concept1(db_session: Session, comic_concept1: Entity) -> E
         comic_concept_entity_id=comic_concept1.id,
         file_entity_id=variant_file_entity.id,
         language="en",
-        format="PDF"
+        format="PDF",
     )
     db_session.commit()
     assert variant_file_entity is not None
     # Add assertion here to check the linked component
     retrieved_variant_comp = ecs_service.get_component(db_session, variant_file_entity.id, ComicBookVariantComponent)
     assert retrieved_variant_comp is not None
-    assert retrieved_variant_comp.conceptual_entity_id == comic_concept1.id, \
+    assert retrieved_variant_comp.conceptual_entity_id == comic_concept1.id, (
         f"Variant {variant_file_entity.id} not linked to concept {comic_concept1.id} correctly in fixture"
+    )
     return variant_file_entity
+
 
 @pytest.fixture
 def generic_entity1(db_session: Session) -> Entity:
@@ -89,16 +90,14 @@ def generic_entity1(db_session: Session) -> Entity:
     assert entity is not None
     return entity
 
+
 # --- Tag Definition Tests ---
+
 
 def test_create_tag_concept(db_session: Session):
     tag_name = "MyUniqueTag"
     tag_entity = ts.create_tag_concept(
-        db_session,
-        tag_name=tag_name,
-        scope_type="GLOBAL",
-        description="Test Description",
-        allow_values=True
+        db_session, tag_name=tag_name, scope_type="GLOBAL", description="Test Description", allow_values=True
     )
     db_session.commit()
     assert tag_entity is not None
@@ -111,11 +110,12 @@ def test_create_tag_concept(db_session: Session):
     assert comp.allow_values is True
 
     # Test duplicate name
-    assert ts.create_tag_concept(db_session, tag_name, "GLOBAL") is tag_entity # Should return existing
+    assert ts.create_tag_concept(db_session, tag_name, "GLOBAL") is tag_entity  # Should return existing
 
     # Test empty name
     with pytest.raises(ValueError, match="Tag name cannot be empty"):
         ts.create_tag_concept(db_session, "", "GLOBAL")
+
 
 def test_get_tag_concept_by_name(db_session: Session, global_tag_concept: Entity):
     retrieved_tag = ts.get_tag_concept_by_name(db_session, "GlobalTestTag")
@@ -123,15 +123,17 @@ def test_get_tag_concept_by_name(db_session: Session, global_tag_concept: Entity
     assert retrieved_tag.id == global_tag_concept.id
     assert ts.get_tag_concept_by_name(db_session, "NonExistentTag") is None
 
+
 def test_get_tag_concept_by_id(db_session: Session, global_tag_concept: Entity):
     retrieved_tag = ts.get_tag_concept_by_id(db_session, global_tag_concept.id)
     assert retrieved_tag is not None
     assert retrieved_tag.id == global_tag_concept.id
     assert ts.get_tag_concept_by_id(db_session, 99999) is None
 
+
 def test_find_tag_concepts(db_session: Session, global_tag_concept: Entity, component_scoped_tag_concept: Entity):
     all_tags = ts.find_tag_concepts(db_session)
-    assert len(all_tags) >= 2 # At least the two created by fixtures
+    assert len(all_tags) >= 2  # At least the two created by fixtures
 
     global_tags = ts.find_tag_concepts(db_session, scope_type="GLOBAL")
     assert global_tag_concept in global_tags
@@ -141,13 +143,10 @@ def test_find_tag_concepts(db_session: Session, global_tag_concept: Entity, comp
     assert len(named_tags) == 1
     assert named_tags[0].id == global_tag_concept.id
 
+
 def test_update_tag_concept(db_session: Session, global_tag_concept: Entity):
     updated_comp = ts.update_tag_concept(
-        db_session,
-        global_tag_concept.id,
-        name="GlobalTestTagUpdated",
-        description="New Desc",
-        allow_values=True
+        db_session, global_tag_concept.id, name="GlobalTestTagUpdated", description="New Desc", allow_values=True
     )
     db_session.commit()
     assert updated_comp is not None
@@ -158,7 +157,7 @@ def test_update_tag_concept(db_session: Session, global_tag_concept: Entity):
     # Test update name conflict
     tag2 = ts.create_tag_concept(db_session, "AnotherTag", "GLOBAL")
     db_session.commit()
-    assert ts.update_tag_concept(db_session, global_tag_concept.id, name="AnotherTag") is None # Should fail
+    assert ts.update_tag_concept(db_session, global_tag_concept.id, name="AnotherTag") is None  # Should fail
 
     # Test clear description
     ts.update_tag_concept(db_session, global_tag_concept.id, description="__CLEAR__")
@@ -187,6 +186,7 @@ def test_delete_tag_concept(db_session: Session, generic_entity1: Entity):
 
 # --- Tag Application Tests ---
 
+
 def test_apply_and_get_tags_for_entity(db_session: Session, global_tag_concept: Entity, generic_entity1: Entity):
     # Apply global tag
     link1 = ts.apply_tag_to_entity(db_session, generic_entity1.id, global_tag_concept.id)
@@ -208,22 +208,27 @@ def test_apply_and_get_tags_for_entity(db_session: Session, global_tag_concept: 
     # Get tags for entity
     applied_tags = ts.get_tags_for_entity(db_session, generic_entity1.id)
     assert len(applied_tags) == 2
-    tag_names_on_entity = {ecs_service.get_component(db_session, tag_concept_e.id, TagConceptComponent).tag_name for tag_concept_e, val in applied_tags}
+    tag_names_on_entity = {
+        ecs_service.get_component(db_session, tag_concept_e.id, TagConceptComponent).tag_name
+        for tag_concept_e, val in applied_tags
+    }
     assert "GlobalTestTag" in tag_names_on_entity
     assert "ValueTag" in tag_names_on_entity
 
     # Test duplicate tag application (label)
-    assert ts.apply_tag_to_entity(db_session, generic_entity1.id, global_tag_concept.id) is None # Already applied
+    assert ts.apply_tag_to_entity(db_session, generic_entity1.id, global_tag_concept.id) is None  # Already applied
 
     # Test duplicate tag application (with value)
-    assert ts.apply_tag_to_entity(db_session, generic_entity1.id, value_tag_concept.id, value="TestValue") is None # Already applied with this value
+    assert (
+        ts.apply_tag_to_entity(db_session, generic_entity1.id, value_tag_concept.id, value="TestValue") is None
+    )  # Already applied with this value
 
     # Test applying value to non-value tag
     # global_tag_concept does not allow values.
     # The service should return None because the pre-check for duplicate label tags will find the existing one.
     link3 = ts.apply_tag_to_entity(db_session, generic_entity1.id, global_tag_concept.id, value="ShouldBeIgnored")
     db_session.commit()
-    assert link3 is None # Expecting None because it's a duplicate application of a label tag.
+    assert link3 is None  # Expecting None because it's a duplicate application of a label tag.
 
 
 def test_remove_tag_from_entity(db_session: Session, global_tag_concept: Entity, generic_entity1: Entity):
@@ -234,10 +239,12 @@ def test_remove_tag_from_entity(db_session: Session, global_tag_concept: Entity,
     assert ts.remove_tag_from_entity(db_session, generic_entity1.id, global_tag_concept.id) is True
     db_session.commit()
     assert len(ts.get_tags_for_entity(db_session, generic_entity1.id)) == 0
-    assert ts.remove_tag_from_entity(db_session, generic_entity1.id, global_tag_concept.id) is False # Already removed
+    assert ts.remove_tag_from_entity(db_session, generic_entity1.id, global_tag_concept.id) is False  # Already removed
 
 
-def test_get_entities_for_tag(db_session: Session, global_tag_concept: Entity, generic_entity1: Entity, comic_concept1: Entity):
+def test_get_entities_for_tag(
+    db_session: Session, global_tag_concept: Entity, generic_entity1: Entity, comic_concept1: Entity
+):
     ts.apply_tag_to_entity(db_session, generic_entity1.id, global_tag_concept.id)
     ts.apply_tag_to_entity(db_session, comic_concept1.id, global_tag_concept.id)
 
@@ -263,7 +270,7 @@ def test_get_entities_for_tag(db_session: Session, global_tag_concept: Entity, g
     # Create a valueless application of Status tag to a new entity
     entity3 = ecs_service.create_entity(db_session)
     db_session.commit()
-    ts.apply_tag_to_entity(db_session, entity3.id, value_tag.id, value=None) # Valueless application
+    ts.apply_tag_to_entity(db_session, entity3.id, value_tag.id, value=None)  # Valueless application
     db_session.commit()
 
     entities_with_status_no_value = ts.get_entities_for_tag(db_session, value_tag.id, filter_by_value_presence=False)
@@ -273,11 +280,12 @@ def test_get_entities_for_tag(db_session: Session, global_tag_concept: Entity, g
 
 # --- Scope Validation Tests ---
 
+
 def test_scope_validation_component_class_required(
     db_session: Session,
-    component_scoped_tag_concept: Entity, # Scope: ComicBookConceptComponent
+    component_scoped_tag_concept: Entity,  # Scope: ComicBookConceptComponent
     comic_concept1: Entity,
-    generic_entity1: Entity
+    generic_entity1: Entity,
 ):
     # Should succeed: comic_concept1 has ComicBookConceptComponent
     link_success = ts.apply_tag_to_entity(db_session, comic_concept1.id, component_scoped_tag_concept.id)
@@ -288,11 +296,12 @@ def test_scope_validation_component_class_required(
     link_fail = ts.apply_tag_to_entity(db_session, generic_entity1.id, component_scoped_tag_concept.id)
     assert link_fail is None
 
+
 def test_scope_validation_conceptual_asset_local(
     db_session: Session,
     comic_concept1: Entity,
     comic_variant1_of_concept1: Entity,
-    local_scoped_tag_concept_for_comic1: Entity # Scope: local to comic_concept1
+    local_scoped_tag_concept_for_comic1: Entity,  # Scope: local to comic_concept1
 ):
     # Tagging the conceptual asset itself should succeed
     link_on_concept = ts.apply_tag_to_entity(db_session, comic_concept1.id, local_scoped_tag_concept_for_comic1.id)
@@ -300,7 +309,9 @@ def test_scope_validation_conceptual_asset_local(
     assert link_on_concept is not None
 
     # Tagging a variant of that conceptual asset should succeed
-    link_on_variant = ts.apply_tag_to_entity(db_session, comic_variant1_of_concept1.id, local_scoped_tag_concept_for_comic1.id)
+    link_on_variant = ts.apply_tag_to_entity(
+        db_session, comic_variant1_of_concept1.id, local_scoped_tag_concept_for_comic1.id
+    )
     db_session.commit()
     assert link_on_variant is not None
 
@@ -313,39 +324,53 @@ def test_scope_validation_conceptual_asset_local(
     # Tagging another comic concept should fail
     comic_concept2 = cbs.create_comic_book_concept(db_session, comic_title="Unrelated Comic")
     db_session.commit()
-    link_on_other_concept = ts.apply_tag_to_entity(db_session, comic_concept2.id, local_scoped_tag_concept_for_comic1.id)
+    link_on_other_concept = ts.apply_tag_to_entity(
+        db_session, comic_concept2.id, local_scoped_tag_concept_for_comic1.id
+    )
     assert link_on_other_concept is None
 
 
 def test_scope_validation_invalid_scope_details(db_session: Session, generic_entity1: Entity):
     # COMPONENT_CLASS_REQUIRED with no detail
-    no_detail_comp_tag = ts.create_tag_concept(db_session, "NoDetailCompTag", "COMPONENT_CLASS_REQUIRED", scope_detail=None)
+    no_detail_comp_tag = ts.create_tag_concept(
+        db_session, "NoDetailCompTag", "COMPONENT_CLASS_REQUIRED", scope_detail=None
+    )
     db_session.commit()
     assert no_detail_comp_tag is not None
     assert ts.apply_tag_to_entity(db_session, generic_entity1.id, no_detail_comp_tag.id) is None
 
     # COMPONENT_CLASS_REQUIRED with non-existent component class name
-    bad_detail_comp_tag = ts.create_tag_concept(db_session, "BadDetailCompTag", "COMPONENT_CLASS_REQUIRED", scope_detail="NonExistentComponent")
+    bad_detail_comp_tag = ts.create_tag_concept(
+        db_session, "BadDetailCompTag", "COMPONENT_CLASS_REQUIRED", scope_detail="NonExistentComponent"
+    )
     db_session.commit()
     assert bad_detail_comp_tag is not None
     assert ts.apply_tag_to_entity(db_session, generic_entity1.id, bad_detail_comp_tag.id) is None
 
     # CONCEPTUAL_ASSET_LOCAL with no detail
-    no_detail_local_tag = ts.create_tag_concept(db_session, "NoDetailLocalTag", "CONCEPTUAL_ASSET_LOCAL", scope_detail=None)
+    no_detail_local_tag = ts.create_tag_concept(
+        db_session, "NoDetailLocalTag", "CONCEPTUAL_ASSET_LOCAL", scope_detail=None
+    )
     db_session.commit()
     assert no_detail_local_tag is not None
     assert ts.apply_tag_to_entity(db_session, generic_entity1.id, no_detail_local_tag.id) is None
 
     # CONCEPTUAL_ASSET_LOCAL with non-integer detail
-    bad_detail_local_tag = ts.create_tag_concept(db_session, "BadDetailLocalTag", "CONCEPTUAL_ASSET_LOCAL", scope_detail="not-an-int")
+    bad_detail_local_tag = ts.create_tag_concept(
+        db_session, "BadDetailLocalTag", "CONCEPTUAL_ASSET_LOCAL", scope_detail="not-an-int"
+    )
     db_session.commit()
     assert bad_detail_local_tag is not None
     assert ts.apply_tag_to_entity(db_session, generic_entity1.id, bad_detail_local_tag.id) is None
 
     # CONCEPTUAL_ASSET_LOCAL where scope_detail ID is not a conceptual asset
-    non_concept_owner = ecs_service.create_entity(db_session) # This entity does not have a BaseConceptualInfoComponent subclass
+    non_concept_owner = ecs_service.create_entity(
+        db_session
+    )  # This entity does not have a BaseConceptualInfoComponent subclass
     db_session.commit()
-    local_to_non_concept_tag = ts.create_tag_concept(db_session, "LocalToNonConcept", "CONCEPTUAL_ASSET_LOCAL", scope_detail=str(non_concept_owner.id))
+    local_to_non_concept_tag = ts.create_tag_concept(
+        db_session, "LocalToNonConcept", "CONCEPTUAL_ASSET_LOCAL", scope_detail=str(non_concept_owner.id)
+    )
     db_session.commit()
     assert local_to_non_concept_tag is not None
     # Applying this tag to anything should fail scope check because the scope itself is defined against a non-conceptual entity


### PR DESCRIPTION
- Systems now inject `WorldConfig` by its class type (as a resource).
- Removed special DI identity handling for 'WorldName' and 'CurrentWorldConfig'.
- Systems needing the world name should inject `WorldConfig` and use `world_config.name`.
- Updated relevant system signatures and internal DI logic in `WorldScheduler`.
- Removed unused `WorldName` and `CurrentWorldConfig` Annotated type aliases from `dam/core/system_params.py` and updated related comments.