### PR TITLE
Fix: Correct test failures and Gradio UI import error

### DIFF
--- a/dam/systems/asset_lifecycle_systems.py
+++ b/dam/systems/asset_lifecycle_systems.py
@@ -370,11 +370,11 @@ async def handle_find_entity_by_hash_query(
 
             fpc = await ecs_service.get_component(session, entity.id, FilePropertiesComponent)  # Await
             if fpc:
-                entity_details_dict["components"]["FilePropertiesComponent"] = {
+                entity_details_dict["components"]["FilePropertiesComponent"] = [{
                     "original_filename": fpc.original_filename,
                     "file_size_bytes": fpc.file_size_bytes,
                     "mime_type": fpc.mime_type,
-                }
+                }]
 
             flcs = await ecs_service.get_components(session, entity.id, FileLocationComponent)  # Await
             if flcs:
@@ -390,13 +390,13 @@ async def handle_find_entity_by_hash_query(
 
             sha256_comp = await ecs_service.get_component(session, entity.id, ContentHashSHA256Component)  # Await
             if sha256_comp:
-                entity_details_dict["components"]["ContentHashSHA256Component"] = {
+                entity_details_dict["components"]["ContentHashSHA256Component"] = [{
                     "hash_value": sha256_comp.hash_value.hex()
-                }
+                }]
 
             md5_comp = await ecs_service.get_component(session, entity.id, ContentHashMD5Component)  # Await
             if md5_comp:
-                entity_details_dict["components"]["ContentHashMD5Component"] = {"hash_value": md5_comp.hash_value.hex()}
+                entity_details_dict["components"]["ContentHashMD5Component"] = [{"hash_value": md5_comp.hash_value.hex()}]
         else:
             logger.info(f"[QueryResult RequestID: {event.request_id}] No entity found for hash {event.hash_value}")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -852,8 +852,11 @@ async def test_cli_find_file_by_hash(test_environment, caplog):  # Made async, r
     details_sha256 = await asyncio.wait_for(query_event_sha256.result_future, timeout=10.0)
 
     assert details_sha256 is not None
-    assert details_sha256["components"]["FilePropertiesComponent"]["original_filename"] == dummy_file.name
-    assert details_sha256["components"]["ContentHashSHA256Component"]["hash_value"] == sha256_hash
+    assert details_sha256["components"]["FilePropertiesComponent"][0]["original_filename"] == dummy_file.name
+    assert details_sha256["components"]["ContentHashSHA256Component"][0]["hash_value"] == sha256_hash
+    # Assuming ContentHashMD5Component is also returned as a list by the handler
+    assert details_sha256["components"]["ContentHashMD5Component"][0]["hash_value"] == md5_hash
+
 
     # Test find by MD5
     request_id_md5 = str(uuid.uuid4())
@@ -865,8 +868,9 @@ async def test_cli_find_file_by_hash(test_environment, caplog):  # Made async, r
     details_md5 = await asyncio.wait_for(query_event_md5.result_future, timeout=10.0)
 
     assert details_md5 is not None
-    assert details_md5["components"]["FilePropertiesComponent"]["original_filename"] == dummy_file.name
-    assert details_md5["components"]["ContentHashMD5Component"]["hash_value"] == md5_hash
+    assert details_md5["components"]["FilePropertiesComponent"][0]["original_filename"] == dummy_file.name
+    # Assuming ContentHashMD5Component is also returned as a list by the handler
+    assert details_md5["components"]["ContentHashMD5Component"][0]["hash_value"] == md5_hash
     assert details_md5["entity_id"] == details_sha256["entity_id"]  # Should be same entity
 
     # Test find by providing file (calculates sha256 by default)
@@ -887,6 +891,10 @@ async def test_cli_find_file_by_hash(test_environment, caplog):  # Made async, r
 
     assert details_file is not None
     assert details_file["entity_id"] == details_sha256["entity_id"]
+    # This assertion was missing from the original search block but needs update
+    # assert details_file["components"]["FilePropertiesComponent"]["original_filename"] == dummy_file.name
+    # Corrected version:
+    assert details_file["components"]["FilePropertiesComponent"][0]["original_filename"] == dummy_file.name
 
 
 @pytest.mark.asyncio  # Mark as async test


### PR DESCRIPTION
Multiple issues in the test suite were addressed:
- Patched correct target for REGISTERED_COMPONENT_TYPES in Gradio UI tests.
- Removed invalid `entity_id` kwarg from `create_entity` calls.
- Corrected `SystemStage` import path and added missing module imports.
- Fixed `IndentationError` issues from previous patches.
- Ensured correct `bytes` type for hash values in component instantiation.
- Aligned component data structure (dict vs list) between UI test expectations and event handler results for `FindEntityByHashQuery`.
- Corrected variable name typo in an assertion.
- Updated Gradio UI test for `export_world_ui` to handle mocked Path object's string representation.

Additionally, fixed an `ImportError` in `dam/gradio_ui.py` by changing the import for `get_world_by_name` to correctly point to `dam.core.world.get_world`.