### PR TITLE
Feat: Use FileExplorer, enhance asset display to tree view, and refin…

### DIFF
--- a/dam/services/ecs_service.py
+++ b/dam/services/ecs_service.py
@@ -96,6 +96,21 @@ async def get_components(session: AsyncSession, entity_id: int, component_type: 
     result = await session.execute(stmt)  # Await execute
     return result.scalars().all()
 
+async def get_all_components_for_entity(session: AsyncSession, entity_id: int) -> List[BaseComponent]:
+    """
+    Retrieves all component instances associated with a given entity_id,
+    checking against all REGISTERED_COMPONENT_TYPES.
+    """
+    all_components: List[BaseComponent] = []
+    if not await get_entity(session, entity_id): # Check if entity exists
+        logger.warning(f"Entity with ID {entity_id} not found when trying to get all its components.")
+        return [] # Or raise an error, depending on desired behavior
+
+    for component_type in REGISTERED_COMPONENT_TYPES:
+        components_of_type = await get_components(session, entity_id, component_type)
+        all_components.extend(components_of_type)
+    return all_components
+
 
 async def remove_component(session: AsyncSession, component: BaseComponent, flush: bool = False) -> None:  # Made async
     """


### PR DESCRIPTION
…e table

- Replaced gr.File with gr.FileExplorer in the Gradio UI for adding assets, allowing selection of both files and folders.
- Updated the `add_assets_ui` function to recursively process files from selected folders.
- Modified `get_asset_details_gr` to structure and display asset component data in a hierarchical/tree-like format within gr.JSON.
  - Entity ID
    - Component Type: <Name>
      - Instance (ID/Name/Profile if available) or Instance Data
        - Attributes
          - key: value
- Enhanced the main asset table (`list_assets_gr` and `assets_df`):
  - Added 'File Size (Bytes)' and 'Created At' columns to the asset listing.
  - Ensured correct data fetching and display for these new columns.
- Added `get_all_components_for_entity` to `ecs_service.py` to support the tree view.
- Updated relevant tests to reflect changes in function signatures, expected data structures, and error messages.