### PR TITLE
Fix: Await list_assets_gr coroutine in Gradio UI .then() call

### DIFF
--- a/dam/gradio_ui.py
+++ b/dam/gradio_ui.py
@@ -752,6 +752,12 @@ async def setup_db_ui() -> str:
         return f"Error: Could not set up database for world '{_active_world.name}'. {str(e)}"
 
 # --- Gradio Interface Definition ---
+
+# Helper async function for the .then() clause to ensure await is handled.
+async def refresh_assets_default():
+    """Calls list_assets_gr with default empty filters and page 1."""
+    return await list_assets_gr(filename_filter="", mime_type_filter="", current_page=1)
+
 def create_dam_ui():
     with gr.Blocks(title="ECS DAM System") as dam_interface:
         gr.Markdown("# ECS Digital Asset Management System")
@@ -974,7 +980,7 @@ def create_dam_ui():
                 eval_run_report_dropdown
             ]
         ).then(
-            lambda: list_assets_gr(filename_filter="", mime_type_filter="", current_page=1),
+            refresh_assets_default, # Replaced lambda with the async helper function
             inputs=[],
             outputs=[assets_df, asset_status_output]
         )


### PR DESCRIPTION
- Resolved a `RuntimeWarning` and `ValueError` in the Gradio UI.
- The `list_assets_gr` coroutine was not being awaited when called via a lambda in a `.then()` clause after world selection.
- Introduced an `async def refresh_assets_default()` helper function that properly awaits `list_assets_gr`.
- Replaced the lambda with this helper function in the `confirm_world_button.click(...).then(...)` chain.