### PR TITLE
Fix: Handle list-type evt.index in Gradio table selection

### DIFF
--- a/dam/gradio_ui.py
+++ b/dam/gradio_ui.py
@@ -186,9 +186,9 @@ async def get_asset_details_gr(evt: gr.SelectData) -> gr.JSON:
     if evt is None or evt.index is None:
         return gr.JSON(value={"info": "Info: Select a row in the table to view asset details."}, label="Asset Details")
 
-    # Ensure evt.index is a tuple of 2 elements (row, col)
-    if not isinstance(evt.index, tuple) or len(evt.index) != 2:
-        return gr.JSON(value={"info": f"Info: Invalid selection event data. Expected (row, col) index. Got: {evt.index}"}, label="Asset Details")
+    # Ensure evt.index is a list or tuple of 2 elements (row, col)
+    if not (isinstance(evt.index, (tuple, list)) and len(evt.index) == 2): # Accept list or tuple
+        return gr.JSON(value={"info": f"Info: Invalid selection event data. Expected (row, col) index as a tuple or list. Got: {evt.index}"}, label="Asset Details")
 
     # Ensure evt.value is not None if we plan to use it directly.
     # If user clicks on a cell that has a None value (e.g. an empty optional field), evt.value would be None.


### PR DESCRIPTION
Modified the get_asset_details_gr function in dam/gradio_ui.py to accept evt.index as either a list or a tuple.
This resolves an issue where asset detail loading failed due to an 'Invalid selection event data' error when evt.index was a list (e.g., [1, 1]).

The table remains functionally non-editable as per the user's requirement.