### PR TITLE
feat: Use UV_TORCH_BACKEND environment variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
         python-version: ["3.12"]
     env:
       DISPLAY: ':99.0'
+      UV_TORCH_BACKEND: 'auto'
 
     steps:
     - uses: actions/checkout@v3
@@ -39,7 +40,7 @@ jobs:
         uv venv .venv
         source .venv/bin/activate
         if [ "${{ matrix.package }}" = "dam" ]; then
-          uv pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+          uv pip install torch torchvision torchaudio
         fi
         uv pip install -e ".[all]"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,30 +17,14 @@ It is recommended to use `uv` for managing virtual environments and dependencies
 
 #### Managing Environment-Specific Dependencies (e.g., CPU-only PyTorch)
 
-Different environments may require different dependencies, such as a CPU-only version of PyTorch in environments without a GPU or with limited disk space. You can manage this by creating separate `requirements.txt` files or by using optional dependency groups in `pyproject.toml`.
-
-**Example using `requirements.txt`:**
-
-You can create a `requirements-cpu.txt` file in the `packages/dam` directory with the following content:
-
-```
---extra-index-url https://download.pytorch.org/whl/cpu
-torch
-torchvision
-torchaudio
-```
-
-Then, when installing dependencies for a CPU-only environment, you would run:
+`uv` provides a convenient way to automatically select the correct PyTorch backend for your environment. To install PyTorch, set the `UV_TORCH_BACKEND` environment variable to `auto` and then run the installation command:
 
 ```bash
-cd packages/dam
-uv pip install -r requirements-cpu.txt
-uv pip install -e .[all]
+export UV_TORCH_BACKEND=auto
+uv pip install torch
 ```
 
-This ensures that the CPU-only version of PyTorch is installed before other dependencies.
-
-**Note for Jules:** When running tests in the provided environment, you **must** install the CPU-only version of PyTorch to avoid running out of disk space.
+This will automatically detect the appropriate backend (CUDA, CPU, etc.) and install the correct version of PyTorch. In the CI environment, this is handled automatically.
 
 #### Running Tests for a Single Package
 

--- a/packages/domarkx/pyproject.toml
+++ b/packages/domarkx/pyproject.toml
@@ -27,6 +27,9 @@ dependencies = [
     "typer",
 ]
 
+[project.optional-dependencies]
+all = []
+
 [project.scripts]
 domarkx = "domarkx.cli:main"
 

--- a/packages/domarkx/tests/test_action_run_tool_code.py
+++ b/packages/domarkx/tests/test_action_run_tool_code.py
@@ -1,6 +1,6 @@
 import pathlib
 from typer.testing import CliRunner
-from domarkx.domarkx.cli import cli_app
+from domarkx.cli import cli_app
 
 runner = CliRunner()
 


### PR DESCRIPTION
This commit updates the CI and `AGENTS.md` to use the `UV_TORCH_BACKEND` environment variable for automatic PyTorch backend selection. This is a cleaner approach than using a command-line flag.