### PR TITLE
I've removed the message separators and updated the tests. Here's a s…

### DIFF
--- a/packages/domarkx/docs/design_conventions.md
+++ b/packages/domarkx/docs/design_conventions.md
@@ -1,0 +1,133 @@
+# Domarkx Markdown Design Conventions
+
+This document outlines the design conventions for creating executable Markdown documents in `domarkx`. Understanding these conventions is crucial for leveraging the full power of the `domarkx` system.
+
+## Core Principles
+
+The design of `domarkx`'s Markdown format is guided by the principle of "executable documentation". The goal is to create documents that are not only human-readable but also machine-parsable and executable. This is achieved by enforcing a structured format that represents a conversation, including user commands and assistant responses with executable code blocks.
+
+## Document Structure
+
+A `domarkx` document is structured as a sequence of messages, optionally preceded by a metadata block (front matter) and a session configuration block.
+
+### 1. Front Matter (Optional)
+
+You can include a YAML front matter block at the beginning of your document to specify global metadata. This block must be enclosed by triple-dashed lines (`---`).
+
+**Example:**
+
+```yaml
+---
+author: Jane Doe
+creation_date: 2023-11-15
+tags: [domarkx, tutorial, conventions]
+---
+```
+
+### 2. Session Configuration (Optional)
+
+You can define a session configuration block to set up the execution environment for the code blocks in the document.
+
+-   The configuration block starts with `` ```session-config `` and ends with ```` ``` ````.
+-   The content of this block must be a valid JSON object.
+-   Immediately following the configuration block, you can include a code block for session setup tasks, such as importing libraries or defining environment variables.
+
+**Example:**
+
+````markdown
+```session-config
+{
+  "engine": "local_shell",
+  "timeout": 60
+}
+```
+
+```python
+import os
+import sys
+
+print("Session initialized.")
+print(f"Python version: {sys.version}")
+```
+````
+
+### 3. Conversation Format
+
+The main body of the document is structured as a conversation.
+
+-   Each message begins with a level-2 heading (`## `) followed by the speaker's role (e.g., `## user` or `## assistant`).
+
+### 4. Message Structure
+
+Each message can consist of three parts: metadata, a blockquote for text, and code blocks.
+
+-   **Message Metadata (Optional):** You can include a JSON block with the language specifier `json msg-metadata` to provide metadata for a specific message.
+
+-   **Blockquote:** Use standard Markdown blockquotes (`> `) for the textual content of the message.
+
+-   **Code Blocks:** Use standard Markdown fenced code blocks (``` ```) to specify executable code.
+    -   You **must** specify the language of the code (e.g., `python`, `bash`).
+    -   You can optionally add a `name` attribute to the code block, which can be used for referencing or saving the code.
+
+**Complete Example:**
+
+```markdown
+---
+title: "Domarkx Design Conventions Demo"
+---
+
+```session-config
+{
+  "engine": "local_shell"
+}
+```
+
+## user
+
+```json msg-metadata
+{
+  "timestamp": "2023-11-15T14:30:00Z"
+}
+```
+
+> Can you show me the files in the current directory?
+
+## assistant
+
+> Certainly. Here is the list of files:
+
+```bash name=list_files.sh
+ls -la
+```
+
+## Analysis of the Design
+
+### Advantages
+
+1.  **Structured and Predictable:** The strict format ensures that documents are consistent and easily parsable, making the system reliable.
+2.  **Modularity:** The separation of concerns (parsing, execution) allows for easy extension and maintenance. For example, adding support for a new language doesn't require changing the core parser.
+3.  **Executable Documentation:** This is the core strength. It's excellent for tutorials, reproducible research, and automating workflows directly within the documentation.
+4.  **Conversational Flow:** The format is a natural fit for representing interactions, especially with LLM-based agents.
+
+### Disadvantages
+
+1.  **Rigid Format:** The biggest drawback is the strict adherence to the format. Any deviation can lead to parsing errors. The error handling is not always verbose enough to pinpoint the exact issue.
+2.  **Lack of Flexibility:** It cannot process existing Markdown files that do not follow this specific convention, requiring manual conversion.
+3.  **Limited Markdown Support:** The parser focuses on its custom structures and may ignore other standard Markdown elements like tables or nested lists within message content.
+4.  **Security Concerns:** Executing code from documents introduces potential security risks. While sandboxing can mitigate this, it's a critical aspect to consider, especially with documents from untrusted sources.
+
+## Future Extensions
+
+Based on the current design, here are some potential directions for future development:
+
+1.  **More Flexible Parser:** Improve the parser to be more tolerant of minor formatting variations and provide more detailed error messages.
+2.  **Expanded Execution Capabilities:**
+    -   Add support for more programming languages (e.g., R, Julia).
+    -   Integrate with more execution backends like Docker containers or remote SSH servers.
+3.  **Enhanced User Experience:**
+    -   Develop an IDE plugin (e.g., for VS Code) with syntax highlighting, autocompletion, and real-time validation.
+    -   Support for rendering rich outputs like plots and images directly in the document.
+4.  **Improved Security and Management:**
+    -   Strengthen the sandboxing environment with fine-grained permission controls.
+    -   Integrate dependency management to declare and install necessary packages for code blocks.
+```

--- a/packages/domarkx/domarkx/utils/chat_doc_parser.py
+++ b/packages/domarkx/domarkx/utils/chat_doc_parser.py
@@ -126,22 +126,14 @@ class MarkdownLLMParser:
         i = 0
         while i < len(lines):
             line = lines[i]
-            if self.state == "start":
-                if line.startswith("```session-config"):
-                    i = self._parse_session_config(lines, i)
-                elif line.startswith("---"):
-                    self.state = "message"
-                    i += 1
-                else:
-                    i += 1
-            elif self.state == "message":
-                if line.startswith("## "):
-                    speaker = line[3:].strip()
-                    i, message = self._parse_message(lines, i + 1, speaker)
-                    self.document.conversation.append(message)
-                    self.state = "start"
-                else:
-                    i += 1
+            if line.startswith("```session-config"):
+                i = self._parse_session_config(lines, i)
+            elif line.startswith("## "):
+                speaker = line[3:].strip()
+                i, message = self._parse_message(lines, i + 1, speaker)
+                self.document.conversation.append(message)
+            else:
+                i += 1
 
     def _parse_session_config(self, lines: List[str], start_index: int) -> int:
         i = start_index + 1
@@ -226,7 +218,6 @@ class MarkdownLLMParser:
 def append_message(writer: io.StringIO, message: Message):
     writer.write(
         f"""
----
 ## {message.speaker}
 
 ```json msg-metadata

--- a/packages/domarkx/tests/test_action_run_tool_code.py
+++ b/packages/domarkx/tests/test_action_run_tool_code.py
@@ -7,11 +7,10 @@ cli_app = setup_test_app()
 
 def test_run_tool_code_action(tmp_path: pathlib.Path):
     md_content = """
----
 ## user
 
 >
----
+
 ## assistant
 
 ```python

--- a/packages/domarkx/uv.lock
+++ b/packages/domarkx/uv.lock
@@ -172,7 +172,15 @@ dependencies = [
     { name = "openai" },
     { name = "prompt-toolkit" },
     { name = "python-dotenv" },
+    { name = "pyyaml" },
     { name = "rich" },
+    { name = "typer" },
+]
+
+[package.optional-dependencies]
+all = [
+    { name = "libcst" },
+    { name = "pytest" },
     { name = "typer" },
 ]
 
@@ -182,12 +190,17 @@ requires-dist = [
     { name = "autogen-core" },
     { name = "autogen-ext", extras = ["openai"] },
     { name = "libcst" },
+    { name = "libcst", marker = "extra == 'all'" },
     { name = "openai" },
     { name = "prompt-toolkit" },
+    { name = "pytest", marker = "extra == 'all'" },
     { name = "python-dotenv" },
+    { name = "pyyaml" },
     { name = "rich" },
     { name = "typer" },
+    { name = "typer", marker = "extra == 'all'" },
 ]
+provides-extras = ["all"]
 
 [[package]]
 name = "h11"
@@ -245,6 +258,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656, upload-time = "2025-04-27T15:29:00.214Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
 ]
 
 [[package]]
@@ -400,6 +422,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
 name = "pillow"
 version = "11.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -463,6 +494,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/77/bc6f92a3e8e6e46c0ca78abfffec0037845800ea38c73483760362804c41/pillow-11.3.0-cp314-cp314t-win32.whl", hash = "sha256:118ca10c0d60b06d006be10a501fd6bbdfef559251ed31b794668ed569c87e12", size = 6377370, upload-time = "2025-07-01T09:15:46.673Z" },
     { url = "https://files.pythonhosted.org/packages/4a/82/3a721f7d69dca802befb8af08b7c79ebcab461007ce1c18bd91a5d5896f9/pillow-11.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8924748b688aa210d79883357d102cd64690e56b923a186f35a82cbc10f997db", size = 7121500, upload-time = "2025-07-01T09:15:48.512Z" },
     { url = "https://files.pythonhosted.org/packages/89/c7/5572fa4a3f45740eaab6ae86fcdf7195b55beac1371ac8c619d880cfe948/pillow-11.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:79ea0d14d3ebad43ec77ad5272e6ff9bba5b679ef73375ea760261207fa8e0aa", size = 2512835, upload-time = "2025-07-01T09:15:50.399Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -555,6 +595,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
…ummary of what I did:

- Updated `MarkdownLLMParser` to remove the dependency on `---` separators.
- Updated `append_message` to no longer write `---` separators.
- Updated `test_action_run_tool_code.py` to remove `---` from the test case.
- Updated `design_conventions.md` to remove mentions of `---` separators.
- Attempted to fix a failing test in `test_python_code_handler.py` related to updating docstrings with `libcst`. I was stuck on this part, as my changes to the `UpdateDocstringTransformer` were not correctly replacing the old docstring.