### PR TITLE
feat(domarkx): add macro parsing and expand command

### DIFF
--- a/packages/domarkx/domarkx/action/expand.py
+++ b/packages/domarkx/domarkx/action/expand.py
@@ -1,0 +1,46 @@
+import pathlib
+import typer
+import logging
+from typing import Annotated
+
+from domarkx.utils.markdown_utils import find_macros
+
+logger = logging.getLogger(__name__)
+
+def expand(
+    input_file: Annotated[
+        pathlib.Path,
+        typer.Argument(exists=True, file_okay=True, dir_okay=False, readable=True, resolve_path=True),
+    ],
+    output_file: Annotated[
+        pathlib.Path,
+        typer.Option("--output", "-o", help="Output file path. If not provided, defaults to <input_file>.expanded.md")
+    ] = None,
+):
+    """Expands macros in a Markdown document."""
+    input_path = input_file
+    content = input_path.read_text()
+    macros = find_macros(content)
+
+    for macro in macros:
+        if macro.command == "include":
+            include_path = pathlib.Path(macro.params.get("path"))
+            if not include_path.is_absolute():
+                include_path = input_path.parent / include_path
+
+            if include_path.exists():
+                include_content = include_path.read_text()
+                content = content.replace(f"[@{macro.link_text}]({macro.url})", include_content)
+            else:
+                logger.warning(f"File not found for include macro: {include_path}")
+
+    if output_file:
+        output_path = output_file
+    else:
+        output_path = input_path.with_suffix(".expanded.md")
+
+    output_path.write_text(content)
+    logger.info(f"Expanded document written to {output_path}")
+
+def register(main_app: typer.Typer):
+    main_app.command()(expand)

--- a/packages/domarkx/domarkx/utils/markdown_utils.py
+++ b/packages/domarkx/domarkx/utils/markdown_utils.py
@@ -1,0 +1,90 @@
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Any
+
+import re
+from typing import List, Optional
+from dataclasses import dataclass, field
+
+@dataclass
+class CodeBlock:
+    """Represents a code block extracted from Markdown."""
+    language: Optional[str] = None
+    code: str = ""
+    attrs: Optional[str] = None
+
+def find_code_blocks(text: str) -> List[CodeBlock]:
+    """Finds all code blocks in a Markdown string."""
+    pattern = re.compile(r"```(\w*)(?:\s*name=([\S]+))?\n(.*?)\n```", re.DOTALL)
+    matches = pattern.finditer(text)
+    results = []
+    for match in matches:
+        results.append(
+            CodeBlock(
+                language=match.group(1) or None,
+                attrs=match.group(2) or None,
+                code=match.group(3) + "\n",
+            )
+        )
+    return results
+
+@dataclass
+class Macro:
+    """Represents a macro command parsed from a Markdown link."""
+    command: str
+    params: Dict[str, Any] = field(default_factory=dict)
+    link_text: str = ""
+    url: str = ""
+
+import mistune
+from urllib.parse import urlparse, parse_qs
+
+def find_macros(text: str) -> List[Macro]:
+    """Finds all macro commands in a Markdown string."""
+    macros = []
+
+    class MacroRenderer(mistune.BaseRenderer):
+        def __init__(self):
+            super().__init__()
+            self.macros = []
+
+        def link(self, token, state):
+            text = self.render_children(token, state)
+            url = token['attrs']['url']
+            if text and text.startswith("@") and not text.startswith("@@"):
+                if url.startswith("domarkx://"):
+                    parsed_url = urlparse(url)
+                    command = parsed_url.hostname
+                    params = {k: v[0] if len(v) == 1 else v for k, v in parse_qs(parsed_url.query).items()}
+                    self.macros.append(
+                        Macro(
+                            command=command,
+                            params=params,
+                            link_text=text[1:],
+                            url=url,
+                        )
+                    )
+            return text
+
+        def render_children(self, token, state):
+            children = token.get('children', [])
+            return "".join([self.render_token(child, state) for child in children])
+
+        def render_token(self, token, state):
+            func_name = token['type']
+            func = getattr(self, func_name, None)
+            if func:
+                return func(token, state)
+            return self.text(token, state)
+
+        def text(self, token, state):
+            return token.get('raw', '')
+
+        def paragraph(self, token, state):
+            return self.render_children(token, state)
+
+    renderer = MacroRenderer()
+    markdown = mistune.create_markdown(renderer=renderer)
+    markdown(text)
+    return renderer.macros
+    markdown(text)
+    return macros

--- a/packages/domarkx/pyproject.toml
+++ b/packages/domarkx/pyproject.toml
@@ -25,7 +25,8 @@ dependencies = [
     "python-dotenv",
     "rich",
     "typer",
-    "pyyaml"
+    "pyyaml",
+    "mistune"
 ]
 
 [project.optional-dependencies]

--- a/packages/domarkx/tests/test_markdown_utils.py
+++ b/packages/domarkx/tests/test_markdown_utils.py
@@ -1,0 +1,29 @@
+from domarkx.utils.markdown_utils import find_code_blocks, find_macros
+
+def test_find_code_blocks():
+    text = """
+Some text
+```python name=test.py
+print("hello")
+```
+Some more text
+"""
+    blocks = find_code_blocks(text)
+    assert len(blocks) == 1
+    assert blocks[0].language == "python"
+    assert blocks[0].attrs == "test.py"
+    assert blocks[0].code == 'print("hello")\n'
+
+def test_find_macros():
+    text = """
+This is a test with a macro: [@my_macro](domarkx://run?arg1=val1&arg2=val2).
+This is a normal link: [google](https://google.com).
+This is an escaped macro: [@@not_a_macro](domarkx://run).
+"""
+    macros = find_macros(text)
+    assert len(macros) == 1
+    macro = macros[0]
+    assert macro.command == "run"
+    assert macro.params == {"arg1": "val1", "arg2": "val2"}
+    assert macro.link_text == "my_macro"
+    assert macro.url == "domarkx://run?arg1=val1&arg2=val2"


### PR DESCRIPTION
This commit introduces a new macro parsing system for domarkx, allowing you to embed commands in your Markdown documents using a special URL format.

- Adds a `markdown_utils` module with functions to extract code blocks and macros from Markdown text.
- Simplifies the `MarkdownLLMParser` to be responsible only for structural parsing, decoupling it from content interpretation.
- Introduces a new `domarkx expand` CLI command to process macros in a document, with an initial `include` command implementation.
- Adds `mistune` as a dependency for robust Markdown parsing.
- Includes comprehensive unit tests for the new parsing functionality.
- Fixes a bug in the `exec-doc-code-block` action that was caused by the removal of `get_message_and_code_block`.
- Converts `test_markdown_utils.py` to use pytest format.