### PR TITLE
I've refactored message creation in `domarkx`.

### DIFF
--- a/packages/domarkx/domarkx/action/exec_doc.py
+++ b/packages/domarkx/domarkx/action/exec_doc.py
@@ -9,7 +9,7 @@ from rich.console import Console
 
 import domarkx.ui.console
 from domarkx.autogen_session import AutoGenSession
-from domarkx.utils.chat_doc_parser import Message, append_message
+from domarkx.utils.chat_doc_parser import append_message
 
 
 async def aexec_doc(doc: pathlib.Path, handle_one_toolcall: bool = False):
@@ -71,7 +71,7 @@ def _append_new_messages(doc, new_state, messages):
 
 {content}"""
         with doc.open("a") as f:
-            append_message(f, Message("assistant", content, message))
+            append_message(f, AutoGenSession.create_message("assistant", content, message))
 
 
 def exec_doc(

--- a/packages/domarkx/domarkx/action/run_tool_code.py
+++ b/packages/domarkx/domarkx/action/run_tool_code.py
@@ -6,7 +6,8 @@ from rich.console import Console
 
 from domarkx.tool_call.run_tool_code.parser import parse_tool_calls
 from domarkx.tool_call.run_tool_code.tool import execute_tool_call, format_assistant_response
-from domarkx.utils.chat_doc_parser import MarkdownLLMParser, Message, append_message
+from domarkx.autogen_session import AutoGenSession
+from domarkx.utils.chat_doc_parser import MarkdownLLMParser, append_message
 
 
 def do_roo_code_action(
@@ -45,7 +46,9 @@ def do_roo_code_action(
         assistant_responses += assistant_response
 
     with doc.open("a") as f:
-        append_message(f, Message("user", assistant_responses, {"source": "user", "type": "UserMessage"}))
+        append_message(
+            f, AutoGenSession.create_message("user", assistant_responses, {"source": "user", "type": "UserMessage"})
+        )
 
 
 def register(main_app: typer.Typer, settings):

--- a/packages/domarkx/domarkx/autogen_session.py
+++ b/packages/domarkx/domarkx/autogen_session.py
@@ -3,8 +3,11 @@ import pathlib
 
 from autogen_ext.models._utils.parse_r1_content import parse_r1_content
 
+import json
+
 from domarkx.agents.resume_funcall_assistant_agent import ResumeFunCallAssistantAgent
 from domarkx.session import Session
+from domarkx.utils.chat_doc_parser import CodeBlock, Message
 
 
 class AutoGenSession(Session):
@@ -12,6 +15,24 @@ class AutoGenSession(Session):
         super().__init__(doc_path)
         self.messages = []
         self.system_message = ""
+
+    @classmethod
+    def create_message(cls, speaker: str, content: str, metadata: dict) -> "Message":
+        """
+        Creates a Message object with metadata as a code block.
+
+        Args:
+            speaker (str): The speaker of the message.
+            content (str): The content of the message.
+            metadata (dict): The metadata of the message.
+
+        Returns:
+            Message: The created Message object.
+        """
+        metadata_code_block = CodeBlock(
+            language="json", attrs="msg-metadata", code=json.dumps(metadata, indent=2, ensure_ascii=False)
+        )
+        return Message(speaker=speaker, content=content, code_blocks=[metadata_code_block])
 
     def _get_last_expression(self, code):
         try:


### PR DESCRIPTION
- I centralized message creation in `AutoGenSession` with a `create_message` class method.
- The `create_message` method now creates a `Message` object with metadata as a code block with the `msg-metadata` attribute.
- I refactored `action/exec_doc.py` and `action/run_tool_code.py` to use the new `create_message` method.