### PR TITLE
Feat: Enhance filename generation in exec_doc

### DIFF
--- a/packages/domarkx/tests/test_action_exec_doc.py
+++ b/packages/domarkx/tests/test_action_exec_doc.py
@@ -1,0 +1,73 @@
+import asyncio
+import pathlib
+import re
+import time
+from unittest.mock import patch
+
+import pytest
+
+from domarkx.action.exec_doc import aexec_doc
+
+VALID_MD_CONTENT = "## user\n\n> hello"
+
+
+class StopTest(Exception):
+    pass
+
+
+@pytest.fixture
+def stop_after_file_creation():
+    with patch("domarkx.action.exec_doc.AutoGenSession", side_effect=StopTest) as mock_session:
+        yield mock_session
+
+
+def test_exec_doc_creates_timestamped_file(tmp_path: pathlib.Path, stop_after_file_creation):
+    test_file = tmp_path / "test.md"
+    test_file.write_text(VALID_MD_CONTENT)
+
+    with pytest.raises(StopTest):
+        asyncio.run(aexec_doc(test_file, overwrite=False))
+
+    created_files = list(tmp_path.glob("test_*.md"))
+    assert len(created_files) == 1
+    new_file = created_files[0]
+    assert re.match(r"test_\d{8}_\d{6}\.md", new_file.name)
+
+
+def test_exec_doc_appends_A_to_timestamped_file(tmp_path: pathlib.Path, stop_after_file_creation):
+    ts_file = tmp_path / "test_20250101_120000.md"
+    ts_file.write_text(VALID_MD_CONTENT)
+
+    with pytest.raises(StopTest):
+        asyncio.run(aexec_doc(ts_file, overwrite=False))
+
+    new_file = tmp_path / "test_20250101_120000A.md"
+    assert new_file.exists()
+
+
+def test_exec_doc_creates_new_timestamp_if_A_exists(tmp_path: pathlib.Path, stop_after_file_creation):
+    ts_file = tmp_path / "test_20250101_120000.md"
+    ts_file.write_text(VALID_MD_CONTENT)
+
+    ts_A_file = tmp_path / "test_20250101_120000A.md"
+    ts_A_file.write_text(VALID_MD_CONTENT)
+
+    # To ensure a new timestamp is generated
+    time.sleep(1)
+
+    with pytest.raises(StopTest):
+        asyncio.run(aexec_doc(ts_file, overwrite=False))
+
+    created_files = list(tmp_path.glob("test_*.md"))
+    # We should have 3 files: original, original_A, and the new one with a new timestamp
+    assert len(created_files) == 3
+
+    new_file = None
+    for f in created_files:
+        if f.name not in [ts_file.name, ts_A_file.name]:
+            new_file = f
+            break
+
+    assert new_file is not None
+    assert re.match(r"test_\d{8}_\d{6}\.md", new_file.name)
+    assert new_file.name != ts_file.name


### PR DESCRIPTION
This commit enhances the filename generation logic in the `exec_doc` action when `overwrite` is false.

The timestamp format for new files has been changed from `YYYY-MM-DD_HH-MM-SS` to `YYYYMMDD_HHMMSS` for better readability and to remove hyphens, as requested.

The logic for handling existing files has been updated:
- If a document with a timestamp in its name is executed, a new file with an 'A' suffix is created (e.g., `file_ts.md` -> `file_tsA.md`). This handles subsequent executions of the same timestamped file.
- If a file with the 'A' suffix already exists, a new file with a fresh timestamp is created from the original base name (e.g., `file_ts2.md`). This handles cases where multiple executions are run from the same source file after the 'A' version has been created.

A new test suite (`test_action_exec_doc.py`) has been added to verify the new filename generation logic under various scenarios, ensuring the changes are robust and correct.