### PR TITLE
ci: Add uv cache to format_and_fix.yml

### DIFF
--- a/.github/workflows/format_and_fix.yml
+++ b/.github/workflows/format_and_fix.yml
@@ -18,6 +18,21 @@ jobs:
       - name: Install dependencies
         run: |
           pip install uv
+
+      - name: Get uv cache directory
+        id: uv-cache-dir
+        run: echo "dir=$(uv cache dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache uv dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.uv-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-uv-3.12-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-3.12-
+
+      - name: Create virtual environment and install dependencies
+        run: |
           uv sync --all-extras
 
       - name: Run formatter and fixer


### PR DESCRIPTION
This change adds the `uv` dependency caching to the `format_and_fix.yml` workflow, mirroring the implementation in `ci.yml`.

This will speed up the workflow by caching the `uv` dependencies.