### PR TITLE
fix: Add database-level length constraint to hash components

### DIFF
--- a/packages/dam/src/dam/models/hashes/content_hash_blake3_component.py
+++ b/packages/dam/src/dam/models/hashes/content_hash_blake3_component.py
@@ -1,13 +1,29 @@
-from sqlalchemy import LargeBinary
+from sqlalchemy import (
+    CheckConstraint,
+    LargeBinary,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
-from dam.models.core.base_component import BaseComponent
+from ..core.base_component import BaseComponent
 
 
 class ContentHashBLAKE3Component(BaseComponent):
+    """
+    Stores BLAKE3 content-based hashes (32 bytes) for an entity.
+    """
+
     __tablename__ = "component_content_hash_blake3"
 
-    hash_value: Mapped[bytes] = mapped_column(LargeBinary(32), nullable=False, unique=True, index=True)
+    hash_value: Mapped[bytes] = mapped_column(LargeBinary(32), index=True, nullable=False)
 
-    def __repr__(self) -> str:
-        return f"ContentHashBLAKE3Component(id={self.id}, hash_value={self.hash_value.hex()})"
+    __table_args__ = (
+        UniqueConstraint("entity_id", "hash_value", name="uq_content_hash_blake3_entity_hash"),
+        CheckConstraint("length(hash_value) = 32", name="cc_content_hash_blake3_hash_value_length"),
+    )
+
+    def __repr__(self):
+        hex_hash = self.hash_value.hex() if isinstance(self.hash_value, bytes) else "N/A"
+        return (
+            f"ContentHashBLAKE3Component(id={self.id}, entity_id={self.entity_id}, hash_value(hex)='{hex_hash[:10]}...')"
+        )

--- a/packages/dam/src/dam/models/hashes/content_hash_crc32_component.py
+++ b/packages/dam/src/dam/models/hashes/content_hash_crc32_component.py
@@ -1,4 +1,8 @@
-from sqlalchemy import LargeBinary, UniqueConstraint
+from sqlalchemy import (
+    CheckConstraint,
+    LargeBinary,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ..core.base_component import BaseComponent
@@ -14,7 +18,10 @@ class ContentHashCRC32Component(BaseComponent):
     # CRC32 hash is 4 bytes (32 bits)
     hash_value: Mapped[bytes] = mapped_column(LargeBinary(4), index=True, nullable=False)
 
-    __table_args__ = (UniqueConstraint("entity_id", "hash_value", name="uq_content_hash_crc32_entity_hash"),)
+    __table_args__ = (
+        UniqueConstraint("entity_id", "hash_value", name="uq_content_hash_crc32_entity_hash"),
+        CheckConstraint("length(hash_value) = 4", name="cc_content_hash_crc32_hash_value_length"),
+    )
 
     def __repr__(self):
         hex_hash = self.hash_value.hex() if isinstance(self.hash_value, bytes) else "N/A"

--- a/packages/dam/src/dam/models/hashes/content_hash_md5_component.py
+++ b/packages/dam/src/dam/models/hashes/content_hash_md5_component.py
@@ -1,7 +1,11 @@
-from sqlalchemy import LargeBinary, UniqueConstraint  # Changed String to LargeBinary
+from sqlalchemy import (
+    CheckConstraint,
+    LargeBinary,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
-from ..core.base_component import BaseComponent  # Corrected import
+from ..core.base_component import BaseComponent
 
 
 class ContentHashMD5Component(BaseComponent):
@@ -14,7 +18,10 @@ class ContentHashMD5Component(BaseComponent):
     # MD5 hash is 16 bytes (128 bits)
     hash_value: Mapped[bytes] = mapped_column(LargeBinary(16), index=True, nullable=False)
 
-    __table_args__ = (UniqueConstraint("entity_id", "hash_value", name="uq_content_hash_md5_entity_hash"),)
+    __table_args__ = (
+        UniqueConstraint("entity_id", "hash_value", name="uq_content_hash_md5_entity_hash"),
+        CheckConstraint("length(hash_value) = 16", name="cc_content_hash_md5_hash_value_length"),
+    )
 
     def __repr__(self):
         hex_hash = self.hash_value.hex() if isinstance(self.hash_value, bytes) else "N/A"

--- a/packages/dam/src/dam/models/hashes/content_hash_sha1_component.py
+++ b/packages/dam/src/dam/models/hashes/content_hash_sha1_component.py
@@ -1,4 +1,8 @@
-from sqlalchemy import LargeBinary, UniqueConstraint
+from sqlalchemy import (
+    CheckConstraint,
+    LargeBinary,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ..core.base_component import BaseComponent
@@ -14,7 +18,10 @@ class ContentHashSHA1Component(BaseComponent):
     # SHA1 hash is 20 bytes (160 bits)
     hash_value: Mapped[bytes] = mapped_column(LargeBinary(20), index=True, nullable=False)
 
-    __table_args__ = (UniqueConstraint("entity_id", "hash_value", name="uq_content_hash_sha1_entity_hash"),)
+    __table_args__ = (
+        UniqueConstraint("entity_id", "hash_value", name="uq_content_hash_sha1_entity_hash"),
+        CheckConstraint("length(hash_value) = 20", name="cc_content_hash_sha1_hash_value_length"),
+    )
 
     def __repr__(self):
         hex_hash = self.hash_value.hex() if isinstance(self.hash_value, bytes) else "N/A"

--- a/packages/dam/src/dam/models/hashes/content_hash_sha256_component.py
+++ b/packages/dam/src/dam/models/hashes/content_hash_sha256_component.py
@@ -1,7 +1,11 @@
-from sqlalchemy import LargeBinary, UniqueConstraint  # Changed String to LargeBinary
+from sqlalchemy import (
+    CheckConstraint,
+    LargeBinary,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
-from ..core.base_component import BaseComponent  # Corrected import
+from ..core.base_component import BaseComponent
 
 
 class ContentHashSHA256Component(BaseComponent):
@@ -19,6 +23,7 @@ class ContentHashSHA256Component(BaseComponent):
         UniqueConstraint(
             "hash_value", name="uq_sha256_hash_value"
         ),  # Hash values themselves are unique across all components
+        CheckConstraint("length(hash_value) = 32", name="cc_content_hash_sha256_hash_value_length"),
     )
 
     def __repr__(self):

--- a/packages/dam/tests/test_hashing_systems.py
+++ b/packages/dam/tests/test_hashing_systems.py
@@ -51,8 +51,10 @@ async def test_add_hashes_from_stream_system_raises_on_mismatch(test_world_alpha
     world = test_world_alpha
     async with world.db_session_maker() as session:
         entity = await ecs_functions.create_entity(session)
-        # Add a component with a wrong hash
-        wrong_hash_comp = ContentHashMD5Component(hash_value=b"wrong_hash")
+        # Add a component with a wrong hash.
+        # The hash must be 16 bytes long to satisfy the database constraint,
+        # but have a value that does not match the actual hash of the data.
+        wrong_hash_comp = ContentHashMD5Component(hash_value=b"a" * 16)
         await ecs_functions.add_component_to_entity(session, entity.id, wrong_hash_comp)
         await session.commit()
         entity_id = entity.id


### PR DESCRIPTION
This commit adds a `CheckConstraint` to all hash component models to enforce the correct length of the hash value at the database level.

Previously, the models used `LargeBinary(N)`, which does not enforce a length constraint on PostgreSQL as it maps to the `BYTEA` type. This allowed hashes of incorrect lengths to be saved to the database.

This commit corrects this by:
- Adding a `CheckConstraint('length(hash_value) = N')` to each of the five hash models.
- Making the `content_hash_blake3_component` model consistent with the others.
- Fixing the test `test_add_hashes_from_stream_system_raises_on_mismatch` to use a mock hash of the correct length, ensuring the test now passes with the new, stricter database constraints.

This change ensures the integrity of hash data stored in the database.