### PR TITLE
Refactor hashing logic for non-seekable streams

### DIFF
--- a/packages/dam/src/dam/systems/hashing_systems.py
+++ b/packages/dam/src/dam/systems/hashing_systems.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, cast, Dict
 
 from dam.core.commands import AddHashesFromStreamCommand
 from dam.core.systems import system
@@ -38,6 +38,58 @@ class HashMismatchError(Exception):
         )
 
 
+async def add_hash_component(
+    transaction: EcsTransaction,
+    entity_id: int,
+    algorithm: HashAlgorithm,
+    hash_value: bytes,
+) -> None:
+    """Adds a single hash component to an entity."""
+    component_class = HASH_ALGORITHM_TO_COMPONENT.get(algorithm)
+    if not component_class:
+        logger.warning(f"No component class found for hash algorithm {algorithm.name}. Skipping.")
+        return
+
+    existing_component = await transaction.get_component(entity_id, component_class)
+
+    if existing_component:
+        existing_component_any = cast(Any, existing_component)
+        if existing_component_any.hash_value != hash_value:
+            raise HashMismatchError(
+                entity_id=entity_id,
+                algorithm=algorithm,
+                existing_hash=existing_component_any.hash_value.hex(),
+                new_hash=hash_value.hex(),
+            )
+    else:
+        new_component = component_class(hash_value=hash_value)
+        await transaction.add_component_to_entity(entity_id, new_component)
+        logger.info(f"Added {component_class.__name__} to entity {entity_id}")
+
+
+async def add_hashes_to_entity(
+    transaction: EcsTransaction,
+    entity_id: int,
+    hashes: Dict[HashAlgorithm, Any],
+) -> None:
+    """
+    Adds multiple hash components to an entity from a dictionary of hashes.
+    """
+    for algorithm, hash_value in hashes.items():
+        # Special handling for CRC32 as it's an int
+        if algorithm == HashAlgorithm.CRC32:
+            hash_value_bytes = hash_value.to_bytes(4, "big")
+        else:
+            hash_value_bytes = hash_value
+
+        await add_hash_component(
+            transaction=transaction,
+            entity_id=entity_id,
+            algorithm=algorithm,
+            hash_value=hash_value_bytes,
+        )
+
+
 @system(on_command=AddHashesFromStreamCommand)
 async def add_hashes_from_stream_system(cmd: AddHashesFromStreamCommand, transaction: EcsTransaction) -> None:
     """
@@ -48,33 +100,17 @@ async def add_hashes_from_stream_system(cmd: AddHashesFromStreamCommand, transac
     hashes = calculate_hashes_from_stream(cmd.stream, cmd.algorithms)
 
     for algorithm, hash_value in hashes.items():
-        component_class = HASH_ALGORITHM_TO_COMPONENT.get(algorithm)
-        if not component_class:
-            logger.warning(f"No component class found for hash algorithm {algorithm.name}. Skipping.")
-            continue
-
-        existing_component = await transaction.get_component(cmd.entity_id, component_class)
-
         # Special handling for CRC32 as it's an int
         if algorithm == HashAlgorithm.CRC32:
             hash_value_bytes = hash_value.to_bytes(4, "big")  # type: ignore
         else:
             hash_value_bytes = hash_value  # type: ignore
 
-        if existing_component:
-            from typing import cast
-
-            existing_component_any = cast(Any, existing_component)
-            if existing_component_any.hash_value != hash_value_bytes:
-                raise HashMismatchError(
-                    entity_id=cmd.entity_id,
-                    algorithm=algorithm,
-                    existing_hash=existing_component_any.hash_value.hex(),
-                    new_hash=hash_value_bytes.hex(),  # type: ignore
-                )
-        else:
-            new_component = component_class(hash_value=hash_value_bytes)  # type: ignore
-            await transaction.add_component_to_entity(cmd.entity_id, new_component)
-            logger.info(f"Added {component_class.__name__} to entity {cmd.entity_id}")
+        await add_hash_component(
+            transaction=transaction,
+            entity_id=cmd.entity_id,
+            algorithm=algorithm,
+            hash_value=hash_value_bytes,
+        )
 
     await transaction.flush()


### PR DESCRIPTION
- Extracts the logic for adding hash components into new functions (`add_hash_component`, `add_hashes_to_entity`) in `dam.systems.hashing_systems`.
- Refactors `add_hashes_from_stream_system` to use the new `add_hash_component` function.
- Modifies `get_or_create_entity_from_stream_handler` to handle non-seekable streams by calculating all hashes in a single pass and using the new `add_hashes_to_entity` function.
- For seekable streams, the behavior is preserved to first check for the entity's existence using its SHA256 hash before calculating all other hashes.