### PR TITLE
feat: Add MIME type handling and refactor archive plugin

### DIFF
--- a/packages/dam_fs/pyproject.toml
+++ b/packages/dam_fs/pyproject.toml
@@ -7,6 +7,7 @@ name = "dam_fs"
 version = "0.1.0"
 dependencies = [
     "dam",
+    "python-magic",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -998,6 +998,7 @@ version = "0.1.0"
 source = { editable = "packages/dam_fs" }
 dependencies = [
     { name = "dam" },
+    { name = "python-magic" },
 ]
 
 [package.optional-dependencies]
@@ -1015,6 +1016,7 @@ requires-dist = [
     { name = "dam-test-utils", marker = "extra == 'dev'", editable = "packages/dam_test_utils" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
+    { name = "python-magic" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
This commit introduces a new MIME type system to the DAM and refactors the archive handling logic based on user feedback.

A `MimeTypeComponent` is added to the `dam` package to store the MIME type of an asset. Its table is named `component_mime_type` to follow project conventions.

`GetMimeTypeCommand`, `SetMimeTypeCommand`, and `AutoSetMimeTypeCommand` and their corresponding systems are added to manage MIME types.

The `auto_set_mime_type_from_filename_system`, located in `dam_fs`, now uses `python-magic` to determine the MIME type from the file's content stream. This system is registered in the `FsPlugin`.

The `dam_archive` plugin is refactored to use the new `MimeTypeComponent`. The old handler registration mechanism is removed, and `open_archive` is updated to use a dictionary mapping MIME types to handlers.

The `process_archives` command in `dam_app` is updated to use a single, efficient query to find archives to process based on their MIME type.

The `show-entity` CLI command is moved from `dam_app/main.py` to `dam_app/cli/assets.py` and renamed to `show`. Its output is changed to JSON format.

A new method `get_first_non_none_value` is added to `CommandResult` to correctly handle `GetAssetStreamCommand` results, and all call sites have been updated.

All relevant tests have been updated to reflect these changes, and all checks pass.