### PR TITLE
feat: Add MIME type handling and refactor archive plugin

### DIFF
--- a/packages/dam/src/dam/commands/__init__.py
+++ b/packages/dam/src/dam/commands/__init__.py
@@ -5,6 +5,7 @@ from .asset_commands import (
     GetAssetStreamCommand,
     GetMimeTypeCommand,
     SetMimeTypeCommand,
+    SetMimeTypeFromBufferCommand,
     UpdateAssetMetadataCommand,
 )
 
@@ -16,4 +17,5 @@ __all__ = [
     "SetMimeTypeCommand",
     "GetMimeTypeCommand",
     "AutoSetMimeTypeCommand",
+    "SetMimeTypeFromBufferCommand",
 ]

--- a/packages/dam/src/dam/commands/asset_commands.py
+++ b/packages/dam/src/dam/commands/asset_commands.py
@@ -38,6 +38,16 @@ class SetMimeTypeCommand(BaseCommand[None]):
 
 
 @dataclass
+class SetMimeTypeFromBufferCommand(BaseCommand[None]):
+    """
+    A command to set the mime type for an asset from a buffer.
+    """
+
+    entity_id: int
+    buffer: bytes
+
+
+@dataclass
 class GetMimeTypeCommand(BaseCommand[str | None]):
     """
     A command to get the mime type for an asset.

--- a/packages/dam/src/dam/utils/stream_utils.py
+++ b/packages/dam/src/dam/utils/stream_utils.py
@@ -1,0 +1,101 @@
+import io
+from typing import IO, Any, Iterable, List, Optional
+
+
+class ChainedStream(io.IOBase):
+    """
+    A stream that concatenates multiple other binary streams, behaving like a single stream.
+    This class is read-only.
+    """
+
+    def __init__(self, streams: List[IO[bytes]]):
+        super().__init__()
+        self.streams = streams
+        self.stream_index = 0
+        self._pos = 0
+
+    def readable(self) -> bool:
+        return True
+
+    def writable(self) -> bool:
+        return False
+
+    def seekable(self) -> bool:
+        return False
+
+    def read(self, size: int = -1) -> bytes:
+        if self.stream_index >= len(self.streams):
+            return b""
+
+        if size == -1:
+            data = b""
+            while self.stream_index < len(self.streams):
+                data += self.streams[self.stream_index].read()
+                self.stream_index += 1
+            self._pos += len(data)
+            return data
+
+        buffer = b""
+        while len(buffer) < size and self.stream_index < len(self.streams):
+            remaining = size - len(buffer)
+            chunk = self.streams[self.stream_index].read(remaining)
+            if not chunk:
+                self.stream_index += 1
+            buffer += chunk
+        self._pos += len(buffer)
+        return buffer
+
+    def readline(self, size: Optional[int] = -1) -> bytes:
+        line = bytearray()
+        limit = size if size is not None and size >= 0 else float("inf")
+        while len(line) < limit:
+            b = self.read(1)
+            if not b:
+                break
+            line.extend(b)
+            if b == b"\n":
+                break
+        return bytes(line)
+
+    def readlines(self, hint: int = -1) -> List[bytes]:
+        lines: List[bytes] = []
+        while True:
+            line = self.readline()
+            if not line:
+                break
+            lines.append(line)
+            if hint > 0 and sum(map(len, lines)) >= hint:
+                break
+        return lines
+
+    def close(self) -> None:
+        for stream in self.streams:
+            try:
+                stream.close()
+            except Exception:
+                pass
+        super().close()
+
+    def tell(self) -> int:
+        return self._pos
+
+    def seek(self, offset: int, whence: int = 0) -> int:
+        raise io.UnsupportedOperation("seek is not supported")
+
+    def write(self, s: bytes) -> int:
+        raise io.UnsupportedOperation("write is not supported")
+
+    def writelines(self, lines: Iterable[Any]) -> None:
+        raise io.UnsupportedOperation("writelines is not supported")
+
+    def truncate(self, size: Optional[int] = None) -> int:
+        raise io.UnsupportedOperation("truncate is not supported")
+
+    def flush(self) -> None:
+        pass
+
+    def isatty(self) -> bool:
+        return False
+
+    def fileno(self) -> int:
+        raise OSError("ChainedStream has no file descriptor")

--- a/packages/dam_fs/src/dam_fs/plugin.py
+++ b/packages/dam_fs/src/dam_fs/plugin.py
@@ -2,6 +2,7 @@ from dam.commands import (
     AutoSetMimeTypeCommand,
     GetAssetFilenamesCommand,
     GetAssetStreamCommand,
+    SetMimeTypeFromBufferCommand,
 )
 from dam.core.plugin import Plugin
 from dam.core.world import World
@@ -23,7 +24,10 @@ from .systems.asset_lifecycle_systems import (
     register_local_file_handler,
     store_assets_handler,
 )
-from .systems.mime_type_system import auto_set_mime_type_from_filename_system
+from .systems.mime_type_system import (
+    auto_set_mime_type_from_filename_system,
+    set_mime_type_from_buffer_system,
+)
 from .systems.stream_handler_system import get_asset_stream_handler
 
 
@@ -60,4 +64,8 @@ class FsPlugin(Plugin):
         world.register_system(
             auto_set_mime_type_from_filename_system,
             command_type=AutoSetMimeTypeCommand,
+        )
+        world.register_system(
+            set_mime_type_from_buffer_system,
+            command_type=SetMimeTypeFromBufferCommand,
         )


### PR DESCRIPTION
This commit introduces a new MIME type system to the DAM and refactors the archive handling logic based on user feedback.

A `MimeTypeComponent` is added to the `dam` package to store the MIME type of an asset. Its table is named `component_mime_type` to follow project conventions.

`GetMimeTypeCommand`, `SetMimeTypeCommand`, `AutoSetMimeTypeCommand`, and `SetMimeTypeFromBufferCommand` and their corresponding systems are added to manage MIME types.

The `auto_set_mime_type_from_filename_system` now uses `python-magic` to determine the MIME type from the file's content stream.

The `dam_archive` plugin is refactored to use the new `MimeTypeComponent`. The old handler registration mechanism is removed, and `open_archive` is updated to use a dictionary mapping MIME types to handlers. The `get_archive_asset_stream_handler` is updated to handle entities that are members of multiple archives.

The `extract_archive_members_handler` is updated to determine the MIME type of extracted members from their file header and to pass the full, reconstructed stream to subsequent commands using a new `ChainedStream` utility.

The `process_archives` command in `dam_app` is updated to use a single, efficient query to find archives to process based on their MIME type.

The `show-entity` CLI command is moved from `dam_app/main.py` to `dam_app/cli/assets.py` and renamed to `show`. Its output is changed to JSON format.

A new method `get_first_non_none_value` is added to `CommandResult` to correctly handle `GetAssetStreamCommand` results, and all call sites have been updated.

All relevant tests have been updated to reflect these changes, and all checks pass.