### PR TITLE
Refactor split archive handling and fix checks

### DIFF
--- a/packages/dam_archive/src/dam_archive/models/split_archive_components.py
+++ b/packages/dam_archive/src/dam_archive/models/split_archive_components.py
@@ -1,8 +1,7 @@
-from typing import List, Optional
+from typing import Optional
 
 from dam.models.core import BaseComponent as Component
-from sqlalchemy import BigInteger, ForeignKey, Integer, String, UniqueConstraint
-from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy import BigInteger, ForeignKey, Integer, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 
@@ -13,7 +12,6 @@ class SplitArchivePartInfoComponent(Component):
 
     __tablename__ = "component_split_archive_part_info"
 
-    base_name: Mapped[str] = mapped_column(String(512), nullable=False, index=True)
     part_num: Mapped[int] = mapped_column(Integer, nullable=False)
     master_entity_id: Mapped[Optional[int]] = mapped_column(
         BigInteger,
@@ -33,7 +31,5 @@ class SplitArchiveManifestComponent(Component):
     """
 
     __tablename__ = "component_split_archive_manifest"
-
-    part_entity_ids: Mapped[List[int]] = mapped_column(ARRAY(BigInteger), nullable=False)
 
     __table_args__ = (UniqueConstraint("entity_id", name="uq_split_archive_manifest_entity_id"),)

--- a/packages/dam_fs/src/dam_fs/models/file_properties_component.py
+++ b/packages/dam_fs/src/dam_fs/models/file_properties_component.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Optional
 
 from dam.models.core.base_component import BaseComponent
+from pydantic import field_validator
 from sqlalchemy import BigInteger, DateTime, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -43,6 +44,12 @@ class FilePropertiesComponent(BaseComponent):
         # this constraint would be removed or made composite with other fields.
         UniqueConstraint("entity_id", name="uq_file_properties_entity_id"),
     )
+
+    @field_validator("file_modified_at")
+    def truncate_microseconds(cls, v: Optional[datetime]) -> Optional[datetime]:
+        if isinstance(v, datetime):
+            return v.replace(microsecond=0)
+        return v
 
     def __repr__(self) -> str:
         return (

--- a/packages/dam_fs/src/dam_fs/systems/asset_lifecycle_systems.py
+++ b/packages/dam_fs/src/dam_fs/systems/asset_lifecycle_systems.py
@@ -89,6 +89,7 @@ async def register_local_file_handler(
         existing_fpc = await transaction.get_component(entity.id, FilePropertiesComponent)
         if not existing_fpc:
             mod_time = datetime.datetime.fromtimestamp(file_path.stat().st_mtime, tz=datetime.timezone.utc)
+            mod_time = mod_time.replace(microsecond=0)  # Truncate to second
             fpc = FilePropertiesComponent(
                 original_filename=file_path.name,
                 file_size_bytes=file_path.stat().st_size,

--- a/packages/dam_fs/tests/test_asset_lifecycle_systems.py
+++ b/packages/dam_fs/tests/test_asset_lifecycle_systems.py
@@ -42,6 +42,7 @@ async def test_register_and_find(test_world_alpha: World, temp_asset_file: Path)
 
     # 2. Find the entity by its properties
     mod_time = datetime.datetime.fromtimestamp(temp_asset_file.stat().st_mtime, tz=datetime.timezone.utc)
+    mod_time = mod_time.replace(microsecond=0)
     find_cmd = FindEntityByFilePropertiesCommand(
         file_path=temp_asset_file.as_uri(),
         file_modified_at=mod_time,


### PR DESCRIPTION
- Remove `part_entity_ids` from `SplitArchiveManifestComponent` and `base_name` from `SplitArchivePartInfoComponent`.
- Update handlers to query the database for split archive parts and order them by `part_num`.
- Refactor `discover_and_bind_handler` to scan the file system and find entities by path and last modified time.
- Modify ingestion logic to use the password from `ArchivePasswordComponent` directly if it exists.
- Fix linting and test errors found by `uv run poe check`.