### PR TITLE
Refactor split archive handling and add skip for processed entities

### DIFF
--- a/packages/dam_archive/src/dam_archive/systems.py
+++ b/packages/dam_archive/src/dam_archive/systems.py
@@ -393,6 +393,11 @@ async def ingest_archive_members_handler(
     """
     logger.info(f"Ingestion command received for entity {cmd.entity_id}")
 
+    info_comp = await transaction.get_component(cmd.entity_id, ArchiveInfoComponent)
+    if info_comp:
+        logger.info(f"Entity {cmd.entity_id} has already been processed. Skipping ingestion.")
+        return
+
     # Case 1: The entity is a master entity for a split archive.
     manifest_comp = await transaction.get_component(cmd.entity_id, SplitArchiveManifestComponent)
     if manifest_comp:


### PR DESCRIPTION
- Remove `part_entity_ids` from `SplitArchiveManifestComponent` and `base_name` from `SplitArchivePartInfoComponent`.
- Update handlers to query the database for split archive parts and order them by `part_num`.
- Refactor `discover_and_bind_handler` to scan the file system and find entities by path and last modified time.
- Modify ingestion logic to use the password from `ArchivePasswordComponent` directly if it exists.
- Add a check in `ingest_archive_members_handler` to skip entities that have already been processed.
- Fix linting and test errors found by `uv run poe check`.