### PR TITLE
feat(dam_app): Refactor CLI and add dynamic MIME processing

### DIFF
--- a/packages/dam_app/src/dam_app/cli/archive.py
+++ b/packages/dam_app/src/dam_app/cli/archive.py
@@ -1,0 +1,107 @@
+from pathlib import Path
+from typing import List
+
+import typer
+from dam_archive.commands import (
+    ClearArchiveComponentsCommand,
+    CreateMasterArchiveCommand,
+    DiscoverAndBindCommand,
+    UnbindSplitArchiveCommand,
+)
+from typing_extensions import Annotated
+
+from dam_app.state import get_world
+from dam_app.utils.async_typer import AsyncTyper
+
+app = AsyncTyper(
+    name="archive",
+    help="Commands for managing archive assets.",
+)
+
+
+@app.command(name="clear-info")
+async def clear_archive_info(
+    entity_id: Annotated[int, typer.Argument(..., help="The ID of the archive entity to clear.")],
+):
+    """
+    Removes archive-related components from an entity and its members.
+
+    This is useful when you want to re-process an archive from scratch.
+    """
+    target_world = get_world()
+    if not target_world:
+        raise typer.Exit(code=1)
+
+    typer.echo(f"Clearing archive info for entity: {entity_id}...")
+
+    clear_cmd = ClearArchiveComponentsCommand(entity_id=entity_id)
+    await target_world.dispatch_command(clear_cmd).get_all_results()
+
+    typer.secho("Archive info clearing process complete.", fg=typer.colors.GREEN)
+
+
+@app.command(name="discover-and-bind")
+async def discover_and_bind(
+    paths: Annotated[
+        List[Path],
+        typer.Argument(
+            ...,
+            help="Path to the asset file or directory to scan.",
+            exists=True,
+            readable=True,
+            resolve_path=True,
+        ),
+    ],
+):
+    """
+    Scans paths for split archive parts, tags them, and binds complete sets.
+    """
+    target_world = get_world()
+    if not target_world:
+        raise typer.Exit(code=1)
+
+    typer.echo(f"Discovering and binding split archives in paths: {paths}...")
+
+    discover_cmd = DiscoverAndBindCommand(paths=[str(p) for p in paths])
+    await target_world.dispatch_command(discover_cmd).get_all_results()
+
+    typer.secho("Discovery and binding process complete.", fg=typer.colors.GREEN)
+
+
+@app.command(name="create-master")
+async def create_master(
+    name: Annotated[str, typer.Option("--name", "-n", help="The name for the master archive entity.")],
+    part_ids: Annotated[List[int], typer.Argument(..., help="An ordered list of entity IDs for the parts.")],
+):
+    """
+    Manually creates a master entity for a split archive from a list of parts.
+    """
+    target_world = get_world()
+    if not target_world:
+        raise typer.Exit(code=1)
+
+    typer.echo(f"Creating master archive '{name}' with parts: {part_ids}...")
+
+    create_cmd = CreateMasterArchiveCommand(name=name, part_entity_ids=part_ids)
+    await target_world.dispatch_command(create_cmd).get_all_results()
+
+    typer.secho("Master archive created successfully.", fg=typer.colors.GREEN)
+
+
+@app.command(name="unbind-master")
+async def unbind_master(
+    master_id: Annotated[int, typer.Argument(..., help="The entity ID of the master archive to unbind.")],
+):
+    """
+    Unbinds a split archive, removing the master entity's manifest and part info.
+    """
+    target_world = get_world()
+    if not target_world:
+        raise typer.Exit(code=1)
+
+    typer.echo(f"Unbinding master archive with ID: {master_id}...")
+
+    unbind_cmd = UnbindSplitArchiveCommand(master_entity_id=master_id)
+    await target_world.dispatch_command(unbind_cmd).get_all_results()
+
+    typer.secho("Master archive unbound successfully.", fg=typer.colors.GREEN)

--- a/packages/dam_app/src/dam_app/main.py
+++ b/packages/dam_app/src/dam_app/main.py
@@ -12,7 +12,7 @@ from dam.core.world import (
 )
 from typing_extensions import Annotated
 
-from dam_app.cli import assets, systems
+from dam_app.cli import archive, assets, systems
 from dam_app.state import get_world, global_state
 from dam_app.utils.async_typer import AsyncTyper
 
@@ -24,6 +24,7 @@ app = AsyncTyper(
 )
 
 app.add_typer(assets.app, name="assets", help="Commands for managing assets.")
+assets.app.add_typer(archive.app, name="archive", help="Commands for managing archive assets.")
 app.add_typer(systems.app, name="systems", help="Commands for running systems.")
 
 

--- a/packages/dam_app/tests/test_cli.py
+++ b/packages/dam_app/tests/test_cli.py
@@ -1,12 +1,14 @@
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from dam.core.commands import BaseCommand
 from dam.core.config import Settings
 from dam.core.world import World
 from pytest import CaptureFixture
 
-from dam_app.cli.assets import clear_archive_info
+from dam_app.cli.archive import clear_archive_info
 
 
 @pytest.mark.serial
@@ -33,7 +35,7 @@ async def test_clear_archive_info_command(capsys: CaptureFixture[Any]):
     mock_stream.get_all_results.return_value = []
     mock_world.dispatch_command.return_value = mock_stream
 
-    with patch("dam_app.cli.assets.get_world", return_value=mock_world):
+    with patch("dam_app.cli.archive.get_world", return_value=mock_world):
         await clear_archive_info(entity_id=entity_id)
 
         # Verify that the correct command was dispatched
@@ -47,3 +49,88 @@ async def test_clear_archive_info_command(capsys: CaptureFixture[Any]):
     captured = capsys.readouterr()
     assert f"Clearing archive info for entity: {entity_id}" in captured.out
     assert "Archive info clearing process complete." in captured.out
+
+
+@pytest.mark.asyncio
+async def test_add_assets_with_process_option(capsys: CaptureFixture[Any], tmp_path: Path):
+    """Test the add_assets command with the --process option."""
+    from dam.commands.asset_commands import AutoSetMimeTypeCommand
+    from dam.models.conceptual.mime_type_concept_component import MimeTypeConceptComponent
+    from dam.models.metadata.content_mime_type_component import ContentMimeTypeComponent
+    from dam_fs.commands import FindEntityByFilePropertiesCommand, RegisterLocalFileCommand
+
+    from dam_app.cli.assets import add_assets
+    from dam_app.commands import ExtractMetadataCommand
+
+    # 1. Setup
+    mock_world = MagicMock(spec=World)
+    mock_session = AsyncMock()
+    mock_world.db_session_maker.return_value.__aenter__.return_value = mock_session
+
+    # Create a side effect function for dispatch_command
+    def dispatch_command_side_effect(command: BaseCommand[Any]):
+        mock_stream = AsyncMock()
+        mock_stream.get_all_results.return_value = []
+        if isinstance(command, FindEntityByFilePropertiesCommand):
+            mock_stream.get_one_value.return_value = None  # File does not exist
+        elif isinstance(command, RegisterLocalFileCommand):
+            mock_stream.get_one_value.return_value = 1  # Return new entity ID
+        else:
+            mock_stream.get_one_value.return_value = None
+        return mock_stream
+
+    mock_world.dispatch_command.side_effect = dispatch_command_side_effect
+
+    # Mock get_component to return a ContentMimeTypeComponent
+    mock_mime_type_concept = MimeTypeConceptComponent(
+        concept_name="image/jpeg", concept_description=None, mime_type="image/jpeg"
+    )
+    mock_mime_type_component = ContentMimeTypeComponent(mime_type_concept_id=1)
+    mock_mime_type_component.mime_type_concept = mock_mime_type_concept
+
+    # 2. Create a temporary file
+    test_file = tmp_path / "test_image.jpg"
+    test_file.write_text("dummy content")
+
+    # We need to patch the ecs_functions.get_component, not a method on the world
+    with (
+        patch("dam_app.cli.assets.get_world", return_value=mock_world),
+        patch(
+            "dam_app.cli.assets.dam_ecs_functions.get_component", return_value=mock_mime_type_component
+        ) as mock_get_component,
+    ):
+        # 3. Call add_assets
+        await add_assets(
+            paths=[test_file],
+            recursive=False,
+            process=["image/jpeg:ExtractMetadataCommand"],
+        )
+
+    # 4. Assertions
+    # Verify that the correct commands were dispatched
+    assert mock_world.dispatch_command.call_count == 4
+
+    # Call 1: FindEntityByFilePropertiesCommand
+    find_cmd = mock_world.dispatch_command.call_args_list[0][0][0]
+    assert isinstance(find_cmd, FindEntityByFilePropertiesCommand)
+
+    # Call 2: RegisterLocalFileCommand
+    register_cmd = mock_world.dispatch_command.call_args_list[1][0][0]
+    assert isinstance(register_cmd, RegisterLocalFileCommand)
+    assert register_cmd.file_path == test_file
+
+    # Call 3: AutoSetMimeTypeCommand
+    auto_set_mime_cmd = mock_world.dispatch_command.call_args_list[2][0][0]
+    assert isinstance(auto_set_mime_cmd, AutoSetMimeTypeCommand)
+    assert auto_set_mime_cmd.entity_id == 1
+
+    # Assert that get_component was called correctly
+    mock_get_component.assert_called_once_with(mock_session, 1, ContentMimeTypeComponent)
+
+    # Call 4: ExtractMetadataCommand
+    extract_cmd = mock_world.dispatch_command.call_args_list[3][0][0]
+    assert isinstance(extract_cmd, ExtractMetadataCommand)
+    assert extract_cmd.entity_id == 1
+
+    captured = capsys.readouterr()
+    assert "Processed test_image.jpg with ExtractMetadataCommand" in captured.out


### PR DESCRIPTION
This commit introduces two main improvements to the `dam-app` CLI:

1.  **CLI Command Refactoring:**
    - The archive-related commands (`clear-archive-info`, `discover-and-bind`, `create-master`, `unbind-master`) have been moved from the `assets` command group to a new, dedicated `archive` subcommand group.
    - The new command structure is `dam-cli assets archive <subcommand>`.

2.  **Dynamic MIME Type Processing:**
    - The `dam-cli assets add` command now includes a `--process` option.
    - This option allows the user to specify a command to be run for a given MIME type immediately after an asset is added.
    - The format is `--process "mime-type:CommandName"`.
    - This enables flexible, on-the-fly metadata extraction workflows.

A new test has been added to verify the `--process` option, and existing tests have been updated to reflect the CLI refactoring.