### PR TITLE
feat: Add filename-based processing and other enhancements

### DIFF
--- a/packages/dam/src/dam/system_events/entity_events.py
+++ b/packages/dam/src/dam/system_events/entity_events.py
@@ -14,3 +14,4 @@ class NewEntityCreatedEvent(BaseSystemEvent):
     entity_id: int
     depth: int
     file_stream: Optional[BinaryIO] = None
+    filename: Optional[str] = None

--- a/packages/dam_archive/src/dam_archive/systems.py
+++ b/packages/dam_archive/src/dam_archive/systems.py
@@ -416,6 +416,7 @@ async def _perform_ingestion(
                         entity_id=member_entity.id,
                         depth=cmd.depth + 1,
                         file_stream=event_file_stream,
+                        filename=member_file.name,
                     )
 
                     member_comp = ArchiveMemberComponent(archive_entity_id=entity_id, path_in_archive=member_file.name)


### PR DESCRIPTION
This commit includes several features and fixes implemented during the session.

### 1. Filename-based Processing in `add_assets`

- Adds an optional `filename: str` field to `NewEntityCreatedEvent`.
- Extends the `--process` option in the `add_assets` CLI command to allow triggering commands based on file extensions (e.g., `.zip:IngestArchiveMembersCommand`) in addition to MIME types.
- Updates the archive ingestion system to populate the new `filename` field in the event.
- Adds new tests to verify this functionality.

### 2. Memory-Constrained Ingestion Logic

- Implements a memory limit for the archive ingestion process in `dam_archive`.
- When extracting a file, it's read into memory only if it's smaller than 50% of available RAM.
- For larger files, a `ChainedStream` is used to allow processing without loading the entire file into memory.
- Adds `psutil` as a dependency.
- Includes a comprehensive test for this logic.

### 3. CI Fixes and Dependency Management

- Fixes a series of `pyright` static analysis errors and subsequent test failures, primarily in the `dam_app` package.
- Adds the `docker` package as a dependency to `domarkx` to resolve a `ModuleNotFoundError` during testing.
- Upgrades all project dependencies to their latest compatible versions using `uv sync --all-extras --upgrade` and verifies that all checks continue to pass.