### PR TITLE
refactor(commands): Standardize command names and add stream support

### DIFF
--- a/packages/dam_archive/src/dam_archive/systems.py
+++ b/packages/dam_archive/src/dam_archive/systems.py
@@ -455,6 +455,15 @@ async def ingest_archive_members_handler(
     """
     logger.info(f"Ingestion command received for entity {cmd.entity_id}")
 
+    # If a stream is provided in the command, use it directly.
+    if cmd.stream:
+        logger.info(f"Processing archive for entity {cmd.entity_id} from provided stream.")
+        async for event in _perform_ingestion(cmd.entity_id, cmd.stream, cmd, world, transaction):
+            yield event
+        return
+
+    # --- Fallback to fetching stream from storage ---
+
     info_comp = await transaction.get_component(cmd.entity_id, ArchiveInfoComponent)
     if info_comp:
         logger.info(f"Entity {cmd.entity_id} has already been processed. Skipping ingestion.")

--- a/packages/dam_psp/src/dam_psp/systems.py
+++ b/packages/dam_psp/src/dam_psp/systems.py
@@ -57,8 +57,10 @@ async def psp_iso_metadata_extraction_command_handler_system(
     """
     entity_id = command.entity_id
     try:
-        # Get the stream
-        stream = await world.dispatch_command(GetAssetStreamCommand(entity_id=entity_id)).get_first_non_none_value()
+        stream = command.stream
+        # If no stream is provided in the command, fetch it from storage.
+        if not stream:
+            stream = await world.dispatch_command(GetAssetStreamCommand(entity_id=entity_id)).get_first_non_none_value()
 
         if stream:
             with stream:


### PR DESCRIPTION
This commit refactors several commands to follow a consistent naming convention and adds an optional `stream` field to allow for more efficient, in-memory processing.

- Renames the following commands:
  - `ExtractMetadataCommand` -> `ExtractExifMetadataCommand`
  - `IngestArchiveMembersCommand` -> `IngestArchiveCommand`
  - `ExtractPSPMetadataCommand` -> `ExtractPspMetadataCommand`
- Adds an optional `stream: Optional[BinaryIO]` field to these commands.
- Updates all references to these commands throughout the codebase, including system handlers, plugins, and tests.
- Modifies the system handlers for these commands to prioritize using the provided `stream` over fetching data from the disk.

feat(cli): Add filename-based processing and stream passing

This commit enhances the `add_assets` command and the underlying event-driven workflow:

- Adds an optional `filename: str` field to `NewEntityCreatedEvent`.
- Extends the `--process` option in `add_assets` to allow triggering commands based on file extensions (e.g., `.zip:IngestArchiveCommand`).
- Optimizes the processing loop to pass the `file_stream` from a `NewEntityCreatedEvent` directly to the `stream` field of the next command, avoiding redundant disk I/O.
- Updates the `ExtractExifMetadataCommand` handler to use the provided stream, writing it to a temporary file for `exiftool` processing.
- Adds and updates tests to verify the new functionality.