### PR TITLE
feat(dam-app): Add progress display and archive benchmark command

### DIFF
--- a/packages/dam_app/src/dam_app/main.py
+++ b/packages/dam_app/src/dam_app/main.py
@@ -24,7 +24,7 @@ app = AsyncTyper(
 )
 
 app.add_typer(assets.app, name="assets", help="Commands for managing assets.")
-assets.app.add_typer(archive.app, name="archive", help="Commands for managing archive assets.")
+app.add_typer(archive.app, name="archive", help="Commands for managing archive assets.")
 app.add_typer(systems.app, name="systems", help="Commands for running systems.")
 
 

--- a/packages/dam_archive/src/dam_archive/systems.py
+++ b/packages/dam_archive/src/dam_archive/systems.py
@@ -114,7 +114,6 @@ async def discover_and_bind_handler(
             for path, mtime in sorted_parts_meta:
                 file_uri = Path(path).as_uri()
                 modified_at = datetime.fromtimestamp(mtime, tz=timezone.utc)
-                modified_at = modified_at.replace(microsecond=0)  # Truncate to second
 
                 # Dispatch command to find entity
                 find_cmd = FindEntityByFilePropertiesCommand(file_path=file_uri, last_modified_at=modified_at)

--- a/packages/dam_fs/tests/test_asset_lifecycle_systems.py
+++ b/packages/dam_fs/tests/test_asset_lifecycle_systems.py
@@ -19,9 +19,7 @@ async def test_register_and_find(test_world_alpha: World, temp_asset_file: Path)
     Tests the full flow of registering a new file and then finding it by its properties.
     """
     world = test_world_alpha
-    mod_time = datetime.datetime.fromtimestamp(temp_asset_file.stat().st_mtime, tz=datetime.timezone.utc).replace(
-        microsecond=0
-    )
+    mod_time = datetime.datetime.fromtimestamp(temp_asset_file.stat().st_mtime, tz=datetime.timezone.utc)
 
     # 1. Register a new file
     register_cmd = RegisterLocalFileCommand(file_path=temp_asset_file)
@@ -88,9 +86,7 @@ async def test_first_seen_at_logic(test_world_alpha: World, tmp_path: Path):
     recent_file = tmp_path / "test_file.txt"
     recent_file.write_text("same content")
     recent_file.touch()  # Update mtime to now
-    recent_mod_time = datetime.datetime.fromtimestamp(recent_file.stat().st_mtime, tz=datetime.timezone.utc).replace(
-        microsecond=0
-    )
+    recent_mod_time = datetime.datetime.fromtimestamp(recent_file.stat().st_mtime, tz=datetime.timezone.utc)
 
     register_cmd1 = RegisterLocalFileCommand(file_path=recent_file)
     entity_id = await world.dispatch_command(register_cmd1).get_one_value()
@@ -99,7 +95,7 @@ async def test_first_seen_at_logic(test_world_alpha: World, tmp_path: Path):
         fnc = await ecs_functions.get_component(session, entity_id, FilenameComponent)
         assert fnc is not None
         assert fnc.first_seen_at is not None
-        assert fnc.first_seen_at.replace(microsecond=0) == recent_mod_time
+        assert fnc.first_seen_at == recent_mod_time
 
     # 2. Create another file with the same name and content but an earlier timestamp
     time.sleep(1)
@@ -113,9 +109,7 @@ async def test_first_seen_at_logic(test_world_alpha: World, tmp_path: Path):
     import os
 
     os.utime(earlier_file, (earlier_mtime_val, earlier_mtime_val))
-    earlier_mod_time = datetime.datetime.fromtimestamp(earlier_mtime_val, tz=datetime.timezone.utc).replace(
-        microsecond=0
-    )
+    earlier_mod_time = datetime.datetime.fromtimestamp(earlier_mtime_val, tz=datetime.timezone.utc)
 
     # 3. Register the older file
     register_cmd2 = RegisterLocalFileCommand(file_path=earlier_file)
@@ -152,9 +146,7 @@ async def test_reregister_modified_file(test_world_alpha: World, temp_asset_file
     # 2. Modify the file
     time.sleep(1)  # Ensure mtime changes
     temp_asset_file.touch()
-    new_mod_time = datetime.datetime.fromtimestamp(temp_asset_file.stat().st_mtime, tz=datetime.timezone.utc).replace(
-        microsecond=0
-    )
+    new_mod_time = datetime.datetime.fromtimestamp(temp_asset_file.stat().st_mtime, tz=datetime.timezone.utc)
 
     assert new_mod_time > original_mtime
 


### PR DESCRIPTION
This commit introduces two main features and a bug fix:

1.  **Enhanced Progress Display:**
    - The `add_assets` command in `dam-app` now provides more detailed, real-time feedback during asset processing.
    - It listens for `SystemProgressEvent` and displays a nested `tqdm` progress bar for each sub-process, showing detailed progress without cluttering the main bar.
    - Persistent messages are used to show which entity is being processed and by which command.

2.  **Archive Benchmark Command:**
    - A new `benchmark` command has been added to the `archive` command group.
    - This command (`dam-cli archive benchmark`) measures the performance of iterating through an archive file.
    - It supports password-protected archives and outputs statistics such as total files, total size, and processing speed (MB/s).

3.  **Bug Fix (Timestamp Precision):**
    - Fixed a bug where tests were failing due to a timestamp precision mismatch.
    - The code has been updated to consistently handle timestamps with full microsecond precision, and the tests have been updated accordingly.