### PR TITLE
feat(dam_app): Allow processing by command name in add_assets

### DIFF
--- a/packages/dam/src/dam/core/commands.py
+++ b/packages/dam/src/dam/core/commands.py
@@ -53,7 +53,6 @@ class EntityCommand(BaseCommand[ResultType, EventType]):
 class AnalysisCommand(EntityCommand[ResultType, EventType]):
     """Base class for commands that analyze an entity's data."""
 
-    depth: int = 0
     stream: BinaryIO | None = None
 
     @classmethod

--- a/packages/dam/src/dam/system_events/entity_events.py
+++ b/packages/dam/src/dam/system_events/entity_events.py
@@ -12,6 +12,5 @@ class NewEntityCreatedEvent(BaseSystemEvent):
     """
 
     entity_id: int
-    depth: int
     file_stream: Optional[BinaryIO] = None
     filename: Optional[str] = None

--- a/packages/dam_app/src/dam_app/cli/systems.py
+++ b/packages/dam_app/src/dam_app/cli/systems.py
@@ -100,7 +100,7 @@ async def ingest_archive(
             task = progress.add_task(f"[cyan]Ingesting archive {entity_id}...", total=None)
 
             if mime_type and mime_type.startswith("application/"):
-                cmd = IngestArchiveCommand(entity_id=entity_id, depth=0, passwords=known_passwords)
+                cmd = IngestArchiveCommand(entity_id=entity_id, passwords=known_passwords)
                 async for event in target_world.dispatch_command(cmd):
                     if isinstance(event, ProgressStarted):
                         progress.update(task, total=100, completed=0)

--- a/packages/dam_app/tests/test_cli.py
+++ b/packages/dam_app/tests/test_cli.py
@@ -81,7 +81,7 @@ async def test_add_assets_with_recursive_process_option(capsys: CaptureFixture[A
         if isinstance(command, IngestArchiveCommand):
 
             async def event_generator(self: AsyncMock):
-                yield NewEntityCreatedEvent(entity_id=2, depth=1, file_stream=mock_file_stream, filename="new_file.jpg")
+                yield NewEntityCreatedEvent(entity_id=2, file_stream=mock_file_stream, filename="new_file.jpg")
 
             mock_stream.__aiter__ = event_generator
         elif isinstance(command, ExtractExifMetadataCommand):

--- a/packages/dam_archive/src/dam_archive/systems.py
+++ b/packages/dam_archive/src/dam_archive/systems.py
@@ -414,7 +414,6 @@ async def _perform_ingestion(
 
                     yield NewEntityCreatedEvent(
                         entity_id=member_entity.id,
-                        depth=cmd.depth + 1,
                         file_stream=event_file_stream,
                         filename=member_file.name,
                     )
@@ -514,9 +513,7 @@ async def ingest_archive_members_handler(
     part_info = await transaction.get_component(cmd.entity_id, SplitArchivePartInfoComponent)
     if part_info and part_info.master_entity_id:
         logger.info(f"Redirecting ingestion from part {cmd.entity_id} to master entity {part_info.master_entity_id}.")
-        redirect_cmd = IngestArchiveCommand(
-            entity_id=part_info.master_entity_id, depth=cmd.depth, passwords=cmd.passwords
-        )
+        redirect_cmd = IngestArchiveCommand(entity_id=part_info.master_entity_id, passwords=cmd.passwords)
         stream = world.dispatch_command(redirect_cmd)
         async for event in stream:
             yield cast(SystemProgressEvent, event)

--- a/packages/dam_archive/tests/test_extraction_system.py
+++ b/packages/dam_archive/tests/test_extraction_system.py
@@ -44,7 +44,7 @@ async def test_ingest_archive_with_stream(test_world_alpha: World, tmp_path: Pat
         entity_id = entity.id
 
     # 3. Run the extraction command with the stream
-    ingest_cmd = IngestArchiveCommand(entity_id=entity_id, depth=0, stream=archive_stream)
+    ingest_cmd = IngestArchiveCommand(entity_id=entity_id, stream=archive_stream)
     async with world.transaction():
         stream = world.dispatch_command(ingest_cmd)
         events = [event async for event in stream]
@@ -90,7 +90,7 @@ async def test_ingestion_with_memory_limit_and_filename(test_world_alpha: World,
     mock_memory.available = 2 * 1024 * 1024  # 2 MB, more than the file size
 
     with patch("dam_archive.systems.psutil.virtual_memory", return_value=mock_memory):
-        ingest_cmd = IngestArchiveCommand(entity_id=entity_id, depth=0)
+        ingest_cmd = IngestArchiveCommand(entity_id=entity_id)
         async with world.transaction():
             stream = world.dispatch_command(ingest_cmd)
             events = [event async for event in stream]
@@ -133,7 +133,7 @@ async def test_ingestion_with_memory_limit(test_world_alpha: World, tmp_path: Pa
         patch("dam_archive.systems.psutil.virtual_memory", return_value=mock_memory),
         patch.object(world, "dispatch_command", wraps=world.dispatch_command) as dispatch_spy,
     ):
-        ingest_cmd_limit = IngestArchiveCommand(entity_id=entity_id, depth=0)
+        ingest_cmd_limit = IngestArchiveCommand(entity_id=entity_id)
         async with world.transaction():
             stream = world.dispatch_command(ingest_cmd_limit)
             events = [event async for event in stream]
@@ -166,7 +166,7 @@ async def test_ingestion_with_memory_limit(test_world_alpha: World, tmp_path: Pa
         patch("dam_archive.systems.psutil.virtual_memory", return_value=mock_memory),
         patch.object(world, "dispatch_command", wraps=world.dispatch_command) as dispatch_spy,
     ):
-        ingest_cmd_no_limit = IngestArchiveCommand(entity_id=entity_id, depth=0)
+        ingest_cmd_no_limit = IngestArchiveCommand(entity_id=entity_id)
         async with world.transaction():
             stream = world.dispatch_command(ingest_cmd_no_limit)
             events = [event async for event in stream]
@@ -203,7 +203,7 @@ async def test_extract_archives(test_world_alpha: World, test_archives: tuple[Pa
         await session.commit()
 
     # 2. Run the extraction command
-    ingest_cmd_reg = IngestArchiveCommand(entity_id=entity_id_reg, depth=0)
+    ingest_cmd_reg = IngestArchiveCommand(entity_id=entity_id_reg)
     async with world.transaction():
         stream = world.dispatch_command(ingest_cmd_reg)
         events = [event async for event in stream]
@@ -233,7 +233,7 @@ async def test_extract_archives(test_world_alpha: World, test_archives: tuple[Pa
         await session.commit()
 
     # 2. Run the extraction command with the correct password
-    ingest_cmd_prot = IngestArchiveCommand(entity_id=entity_id_prot, depth=0, passwords=["password"])
+    ingest_cmd_prot = IngestArchiveCommand(entity_id=entity_id_prot, passwords=["password"])
     async with world.transaction():
         stream = world.dispatch_command(ingest_cmd_prot)
         events = [event async for event in stream]
@@ -272,7 +272,7 @@ async def test_skip_already_extracted(test_world_alpha: World, test_archives: tu
         await session.commit()
 
     # 2. Run the extraction command for the first time
-    ingest_cmd1 = IngestArchiveCommand(entity_id=entity_id, depth=0)
+    ingest_cmd1 = IngestArchiveCommand(entity_id=entity_id)
     async with world.transaction():
         stream1 = world.dispatch_command(ingest_cmd1)
         events1 = [event async for event in stream1]
@@ -285,7 +285,7 @@ async def test_skip_already_extracted(test_world_alpha: World, test_archives: tu
         assert info1.comment == "regular archive comment"
 
     # 4. Run the extraction command for the second time
-    ingest_cmd2 = IngestArchiveCommand(entity_id=entity_id, depth=0)
+    ingest_cmd2 = IngestArchiveCommand(entity_id=entity_id)
     async with world.transaction():
         stream2 = world.dispatch_command(ingest_cmd2)
         events2 = [event async for event in stream2]

--- a/packages/dam_psp/src/dam_psp/systems.py
+++ b/packages/dam_psp/src/dam_psp/systems.py
@@ -41,7 +41,7 @@ async def psp_iso_metadata_extraction_event_handler_system(
             is_iso = any(filename.lower().endswith(".iso") for filename in all_filenames)
 
             if is_iso:
-                await world.dispatch_command(ExtractPSPMetadataCommand(entity_id=entity_id, depth=0)).get_all_results()
+                await world.dispatch_command(ExtractPSPMetadataCommand(entity_id=entity_id)).get_all_results()
 
         except Exception as e:
             logger.error(f"Failed during PSP ISO metadata processing for entity {entity_id}: {e}", exc_info=True)

--- a/packages/dam_psp/tests/test_ingestion.py
+++ b/packages/dam_psp/tests/test_ingestion.py
@@ -220,7 +220,7 @@ async def test_psp_iso_metadata_extraction_with_stream(mocker: MockerFixture) ->
     dummy_stream = create_dummy_iso_with_sfo()
 
     # 2. Execute command handler with a stream
-    command = ExtractPSPMetadataCommand(entity_id=entity_id, depth=0, stream=dummy_stream)
+    command = ExtractPSPMetadataCommand(entity_id=entity_id, stream=dummy_stream)
     await psp_iso_metadata_extraction_command_handler_system(command, mock_transaction, mock_world)
 
     # 3. Assertions


### PR DESCRIPTION
This change enhances the `add_assets` command in `dam_app` to provide a more user-friendly way to specify processing commands.

Previously, the `--process` option required a specific MIME type or file extension prefix (e.g., `image/jpeg:ExtractExifMetadataCommand`). This change introduces the ability to pass just the command name (e.g., `ExtractExifMetadataCommand`).

Key Improvements:
- A new `get_supported_types()` class method on the `AnalysisCommand` base class allows plugins to declare the file types they support.
- `ExtractExifMetadataCommand` now dynamically discovers supported extensions by running `exiftool -listr` at runtime and caching the result.
- The `add_assets` command's processing logic has been enhanced:
  - It now supports the new command-name-only syntax for the `--process` option.
  - It prioritizes MIME-type matches over file extension matches to resolve ambiguity.
  - It handles file extensions case-insensitively.
  - It correctly manages stream resources for recursive processing.
- The `depth` parameter has been refactored out of commands and events for cleaner recursion control.
- Unit tests have been updated to cover all new functionality.