### PR TITLE
Refactor AutoSetMimeTypeCommand and improve mimetype detection

### DIFF
--- a/packages/dam/src/dam/commands/__init__.py
+++ b/packages/dam/src/dam/commands/__init__.py
@@ -1,5 +1,5 @@
+from .analysis_commands import AutoSetMimeTypeCommand
 from .asset_commands import (
-    AutoSetMimeTypeCommand,
     GetAssetFilenamesCommand,
     GetAssetMetadataCommand,
     GetAssetStreamCommand,

--- a/packages/dam/src/dam/commands/analysis_commands.py
+++ b/packages/dam/src/dam/commands/analysis_commands.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+from dam.core.commands import AnalysisCommand
+from dam.system_events import BaseSystemEvent
+
+
+@dataclass
+class AutoSetMimeTypeCommand(AnalysisCommand[None, BaseSystemEvent]):
+    """
+    A command to automatically set the mime type for an asset.
+    """
+
+    entity_id: int

--- a/packages/dam/src/dam/commands/asset_commands.py
+++ b/packages/dam/src/dam/commands/asset_commands.py
@@ -20,15 +20,6 @@ class GetAssetStreamCommand(BaseCommand[BinaryIO, BaseSystemEvent]):
 
 
 @dataclass
-class AutoSetMimeTypeCommand(BaseCommand[None, BaseSystemEvent]):
-    """
-    A command to automatically set the mime type for an asset or all assets.
-    """
-
-    entity_id: int | None = None
-
-
-@dataclass
 class SetMimeTypeCommand(BaseCommand[None, BaseSystemEvent]):
     """
     A command to set the mime type for an asset.

--- a/packages/dam_app/src/dam_app/cli/assets.py
+++ b/packages/dam_app/src/dam_app/cli/assets.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import typer
-from dam.commands.asset_commands import (
+from dam.commands import (
     AutoSetMimeTypeCommand,
     SetMimeTypeCommand,
 )


### PR DESCRIPTION
- Moved AutoSetMimeTypeCommand to a new file `analysis_commands.py` under `dam/commands`.
- Changed AutoSetMimeTypeCommand to inherit from AnalysisCommand.
- Updated the `auto_set_mime_type_from_filename_system` in `dam_fs` to:
  - Use the refactored AutoSetMimeTypeCommand.
  - Fallback to checking file extensions for zip, rar, and 7z files if the `magic` library returns `application/octet-stream`.
- Updated all necessary imports and passed all tests.