### PR TITLE
Refactor: Make transaction_manager private and add context methods

### DIFF
--- a/packages/dam/tests/test_hashing_systems.py
+++ b/packages/dam/tests/test_hashing_systems.py
@@ -3,6 +3,7 @@ from io import BytesIO
 import pytest
 
 from dam.commands.hashing_commands import AddHashesFromStreamCommand
+from dam.core.transaction import WorldTransaction
 from dam.core.world import World
 from dam.functions import ecs_functions
 from dam.models.hashes import (
@@ -19,7 +20,7 @@ async def test_add_hashes_from_stream_system(test_world_alpha: World) -> None:
     Tests that the add_hashes_from_stream_system correctly adds hash components.
     """
     world = test_world_alpha
-    tm = world.transaction_manager
+    tm = world.get_context(WorldTransaction)
     async with tm() as transaction:
         entity = await ecs_functions.create_entity(transaction.session)
         await transaction.session.commit()
@@ -54,7 +55,7 @@ async def test_add_hashes_from_stream_system_propagates_mismatch_error(
     Tests that the system propagates a HashMismatchError if a hash already exists and does not match.
     """
     world = test_world_alpha
-    tm = world.transaction_manager
+    tm = world.get_context(WorldTransaction)
     async with tm() as transaction:
         entity = await ecs_functions.create_entity(transaction.session)
         # Add a component with a wrong hash.

--- a/packages/dam_app/src/dam_app/cli/assets.py
+++ b/packages/dam_app/src/dam_app/cli/assets.py
@@ -11,6 +11,7 @@ from dam.commands.asset_commands import (
     GetMimeTypeCommand,
     SetMimeTypeCommand,
 )
+from dam.core.transaction import WorldTransaction
 from dam.functions import ecs_functions as dam_ecs_functions
 from dam.system_events.entity_events import NewEntityCreatedEvent
 from dam.system_events.progress import (
@@ -339,7 +340,7 @@ async def show_entity(
     if not target_world:
         raise typer.Exit(code=1)
 
-    async with target_world.transaction_manager() as tx:
+    async with target_world.get_context(WorldTransaction)() as tx:
         session = tx.session
         components_dict = await dam_ecs_functions.get_all_components_for_entity_as_dict(session, entity_id)
         if not components_dict:

--- a/packages/dam_app/src/dam_app/cli/systems.py
+++ b/packages/dam_app/src/dam_app/cli/systems.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import typer
+from dam.core.transaction import WorldTransaction
 from dam.events.asset_events import AssetReadyForMetadataExtractionEvent
 from dam.models.core.entity import Entity
 from dam.models.metadata.content_mime_type_component import ContentMimeTypeComponent
@@ -64,7 +65,7 @@ async def run_auto_tagging(
 
     typer.echo(f"Running auto-tagging for entity: {entity_id}...")
 
-    async with target_world.transaction_manager() as tx:
+    async with target_world.get_context(WorldTransaction)() as tx:
         session = tx.session
         entity = await session.get(Entity, entity_id)
         if not entity:
@@ -89,7 +90,7 @@ async def ingest_archive(
     if not target_world:
         raise typer.Exit(code=1)
 
-    async with target_world.transaction_manager() as tx:
+    async with target_world.get_context(WorldTransaction)() as tx:
         session = tx.session
         mime_type_comp = await session.get(ContentMimeTypeComponent, entity_id)
         mime_type = ""

--- a/packages/dam_app/src/dam_app/main.py
+++ b/packages/dam_app/src/dam_app/main.py
@@ -5,6 +5,7 @@ from typing import Optional
 import typer
 from dam.core import config as app_config
 from dam.core.logging_config import setup_logging
+from dam.core.transaction import WorldTransaction
 from dam.core.world import (
     clear_world_registry,
     create_and_register_all_worlds_from_settings,
@@ -55,7 +56,11 @@ async def setup_db(ctx: typer.Context):
         raise typer.Exit(code=1)
     typer.echo(f"Setting up database for world: '{target_world.name}'...")
     try:
-        await target_world.transaction_manager.create_db_and_tables()
+        from dam.core.transaction_manager import TransactionManager
+
+        transaction_manager = target_world.get_context(WorldTransaction)
+        assert isinstance(transaction_manager, TransactionManager)
+        await transaction_manager.create_db_and_tables()
         typer.secho("Database setup complete.", fg=typer.colors.GREEN)
     except Exception as e:
         typer.secho(f"Error during database setup: {e}", fg=typer.colors.RED)

--- a/packages/dam_app/tests/test_cli.py
+++ b/packages/dam_app/tests/test_cli.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from dam.commands.core import BaseCommand
 from dam.core.config import Settings
+from dam.core.transaction import WorldTransaction
 from dam.core.world import World
 from pytest import CaptureFixture
 
@@ -66,11 +67,11 @@ async def test_add_assets_with_recursive_process_option(capsys: CaptureFixture[A
 
     # 1. Setup
     mock_world = MagicMock(spec=World)
-    mock_world.transaction_manager = AsyncMock()
+    mock_world.get_context.return_value = AsyncMock()
     mock_session = AsyncMock()
-    mock_tx = AsyncMock()
+    mock_tx = AsyncMock(spec=WorldTransaction)
     mock_tx.session = mock_session
-    mock_world.transaction_manager.return_value.__aenter__.return_value = mock_tx
+    mock_world.get_context.return_value.return_value.__aenter__.return_value = mock_tx
 
     mock_file_content = b"This is the content of the new file."
 
@@ -163,11 +164,11 @@ async def test_add_assets_with_extension_process_option(capsys: CaptureFixture[A
 
     # 1. Setup
     mock_world = MagicMock(spec=World)
-    mock_world.transaction_manager = AsyncMock()
+    mock_world.get_context.return_value = AsyncMock()
     mock_session = AsyncMock()
-    mock_tx = AsyncMock()
+    mock_tx = AsyncMock(spec=WorldTransaction)
     mock_tx.session = mock_session
-    mock_world.transaction_manager.return_value.__aenter__.return_value = mock_tx
+    mock_world.get_context.return_value.return_value.__aenter__.return_value = mock_tx
 
     # Create a side effect function for dispatch_command
     def dispatch_command_side_effect(command: BaseCommand[Any, Any], **kwargs: Any):
@@ -233,11 +234,11 @@ async def test_add_assets_with_command_name_process_option(capsys: CaptureFixtur
     ExtractExifMetadataCommand._cached_extensions = None  # type: ignore [protected-access]
 
     mock_world = MagicMock(spec=World)
-    mock_world.transaction_manager = AsyncMock()
+    mock_world.get_context.return_value = AsyncMock()
     mock_session = AsyncMock()
-    mock_tx = AsyncMock()
+    mock_tx = AsyncMock(spec=WorldTransaction)
     mock_tx.session = mock_session
-    mock_world.transaction_manager.return_value.__aenter__.return_value = mock_tx
+    mock_world.get_context.return_value.return_value.__aenter__.return_value = mock_tx
 
     # Create a side effect function for dispatch_command
     def dispatch_command_side_effect(command: BaseCommand[Any, Any], **kwargs: Any):

--- a/packages/dam_app/tests/test_cli_character.py
+++ b/packages/dam_app/tests/test_cli_character.py
@@ -2,6 +2,7 @@ from pathlib import Path  # Missing import
 from typing import Optional  # For asset_sha256 type hint
 
 import pytest
+from dam.core.transaction import WorldTransaction
 from dam.core.world import World
 from dam.functions import character_functions as character_service
 from dam.functions import ecs_functions as ecs_service
@@ -16,7 +17,7 @@ async def test_cli_character_create(test_world_alpha: World):
 
     # Bypassing CliRunner for this async command due to execution issues.
     # Directly test the service layer logic.
-    async with test_world_alpha.transaction_manager() as tx:
+    async with test_world_alpha.get_context(WorldTransaction)() as tx:
         session = tx.session
         # Initial creation
         char_entity = await character_service.create_character_concept(
@@ -26,7 +27,7 @@ async def test_cli_character_create(test_world_alpha: World):
         assert char_entity is not None
         char_entity_id = char_entity.id
 
-    async with test_world_alpha.transaction_manager() as tx:
+    async with test_world_alpha.get_context(WorldTransaction)() as tx:
         session = tx.session
         # DB checks for initial creation
         retrieved_char_entity = await character_service.get_character_concept_by_name(session, char_name)
@@ -37,7 +38,7 @@ async def test_cli_character_create(test_world_alpha: World):
         assert char_comp.concept_name == char_name
         assert char_comp.concept_description == char_desc
 
-    async with test_world_alpha.transaction_manager() as tx:
+    async with test_world_alpha.get_context(WorldTransaction)() as tx:
         session = tx.session
         # Test creating again (should return existing or handle gracefully by service)
         # The service function create_character_concept logs a warning and returns existing if found.
@@ -50,7 +51,7 @@ async def test_cli_character_create(test_world_alpha: World):
         assert existing_char_entity_again is not None
         assert existing_char_entity_again.id == char_entity_id  # Should be the same entity
 
-    async with test_world_alpha.transaction_manager() as tx:
+    async with test_world_alpha.get_context(WorldTransaction)() as tx:
         session = tx.session
         # Verify that the description was NOT updated (service returns existing, doesn't update)
         char_comp_after_dupe_attempt = await ecs_service.get_component(
@@ -61,7 +62,7 @@ async def test_cli_character_create(test_world_alpha: World):
 
     # Test validation (e.g., empty name) by trying to call the service function
     with pytest.raises(ValueError, match="Character name cannot be empty."):
-        async with test_world_alpha.transaction_manager() as tx:
+        async with test_world_alpha.get_context(WorldTransaction)() as tx:
             session = tx.session
             await character_service.create_character_concept(session=session, name="", description="Test empty name")
             await session.commit()  # Should not be reached
@@ -74,7 +75,7 @@ async def test_cli_character_apply_list_find(  # Made async
     # 1. Create a character by directly calling the service
     char_name = "Linkable Service Char"
     char_id: Optional[int] = None
-    async with test_world_alpha.transaction_manager() as tx:
+    async with test_world_alpha.get_context(WorldTransaction)() as tx:
         session = tx.session
         char_entity = await character_service.create_character_concept(session, name=char_name)
         await session.commit()
@@ -85,7 +86,7 @@ async def test_cli_character_apply_list_find(  # Made async
     # 2. Add a dummy asset by directly calling the service
     asset_id: Optional[int] = None
     asset_filename = "asset_for_char_link_service.txt"
-    async with test_world_alpha.transaction_manager() as tx:
+    async with test_world_alpha.get_context(WorldTransaction)() as tx:
         session = tx.session
         from datetime import datetime, timezone
 
@@ -104,7 +105,7 @@ async def test_cli_character_apply_list_find(  # Made async
 
     # 3. Apply character to asset (using service call)
     role = "Main Protagonist Service"
-    async with test_world_alpha.transaction_manager() as tx:
+    async with test_world_alpha.get_context(WorldTransaction)() as tx:
         session = tx.session
         link_component = await character_service.apply_character_to_entity(
             session=session,
@@ -117,7 +118,7 @@ async def test_cli_character_apply_list_find(  # Made async
         assert link_component.role_in_asset == role
 
     # Verify link in DB (already part of the above apply logic implicitly, but can be explicit)
-    async with test_world_alpha.transaction_manager() as tx:
+    async with test_world_alpha.get_context(WorldTransaction)() as tx:
         session = tx.session
         links = await ecs_service.get_components(session, asset_id, EntityCharacterLinkComponent)
         assert len(links) == 1
@@ -125,7 +126,7 @@ async def test_cli_character_apply_list_find(  # Made async
         assert links[0].role_in_asset == role
 
     # 4. List characters for the asset (using service call)
-    async with test_world_alpha.transaction_manager() as tx:
+    async with test_world_alpha.get_context(WorldTransaction)() as tx:
         session = tx.session
         characters_on_asset = await character_service.get_characters_for_entity(session, asset_id)
         assert len(characters_on_asset) == 1
@@ -137,7 +138,7 @@ async def test_cli_character_apply_list_find(  # Made async
         assert char_comp.concept_name == char_name
 
     # 5. Find assets for the character (using service call)
-    async with test_world_alpha.transaction_manager() as tx:
+    async with test_world_alpha.get_context(WorldTransaction)() as tx:
         session = tx.session
         linked_assets = await character_service.get_entities_for_character(session, char_id)
         assert len(linked_assets) == 1
@@ -147,7 +148,7 @@ async def test_cli_character_apply_list_find(  # Made async
         assert fnc.filename == asset_filename
 
     # 6. Find assets for character with role filter (using service call)
-    async with test_world_alpha.transaction_manager() as tx:
+    async with test_world_alpha.get_context(WorldTransaction)() as tx:
         session = tx.session
         linked_assets_role_filter = await character_service.get_entities_for_character(
             session, char_id, role_filter=role
@@ -156,7 +157,7 @@ async def test_cli_character_apply_list_find(  # Made async
         assert linked_assets_role_filter[0].id == asset_id
 
     # Test finding with non-existent role (using service call)
-    async with test_world_alpha.transaction_manager() as tx:
+    async with test_world_alpha.get_context(WorldTransaction)() as tx:
         session = tx.session
         linked_assets_wrong_role = await character_service.get_entities_for_character(
             session, char_id, role_filter="NonExistentRole"
@@ -200,7 +201,7 @@ async def test_cli_character_apply_with_identifiers(  # Made async
     asset_id_for_test: Optional[int] = None
     asset_sha256_from_db: Optional[str] = None
 
-    async with test_world_alpha.transaction_manager() as tx:
+    async with test_world_alpha.get_context(WorldTransaction)() as tx:
         session = tx.session
         entities = await ecs_service.find_entities_by_component_attribute_value(
             session, FilenameComponent, "filename", sample_image_a.name
@@ -218,7 +219,7 @@ async def test_cli_character_apply_with_identifiers(  # Made async
 
     char_name_for_hash_test = "CharForHashAssetTestSvc"
     char_id_for_hash_test: Optional[int] = None
-    async with test_world_alpha.transaction_manager() as tx:
+    async with test_world_alpha.get_context(WorldTransaction)() as tx:
         session = tx.session
         char_entity = await character_service.create_character_concept(session, name=char_name_for_hash_test)
         await session.commit()
@@ -232,7 +233,7 @@ async def test_cli_character_apply_with_identifiers(  # Made async
     assert asset_id_for_test is not None
     assert char_id_for_hash_test is not None
 
-    async with test_world_alpha.transaction_manager() as tx:
+    async with test_world_alpha.get_context(WorldTransaction)() as tx:
         session = tx.session
         link_component = await character_service.apply_character_to_entity(
             session=session,
@@ -244,14 +245,14 @@ async def test_cli_character_apply_with_identifiers(  # Made async
         assert link_component is not None
 
     # Verify in DB
-    async with test_world_alpha.transaction_manager() as tx:
+    async with test_world_alpha.get_context(WorldTransaction)() as tx:
         session = tx.session
         links = await ecs_service.get_components(session, asset_id_for_test, EntityCharacterLinkComponent)
         assert len(links) == 1
         assert links[0].character_concept_entity_id == char_id_for_hash_test
 
     # 4. List characters for asset using asset ID (service call)
-    async with test_world_alpha.transaction_manager() as tx:
+    async with test_world_alpha.get_context(WorldTransaction)() as tx:
         session = tx.session
         characters_on_asset = await character_service.get_characters_for_entity(session, asset_id_for_test)
         assert len(characters_on_asset) == 1

--- a/packages/dam_archive/tests/test_archive_commands.py
+++ b/packages/dam_archive/tests/test_archive_commands.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Annotated, List
 
 import pytest
+from dam.core.transaction import WorldTransaction
 from dam.core.world import World
 from dam_fs.commands import RegisterLocalFileCommand
 from sqlalchemy import select
@@ -46,7 +47,7 @@ async def test_discover_and_bind_workflow(
     await asyncio.sleep(0.1)
 
     # 3. Assertions
-    tm = world.transaction_manager
+    tm = world.get_context(WorldTransaction)
     async with tm() as transaction:
         session = transaction.session
         manifest_query = await session.execute(select(SplitArchiveManifestComponent))
@@ -75,7 +76,7 @@ async def test_manual_create_and_unbind_workflow(
     entity_ids: List[int] = []
 
     # 1. Setup: Manually create part entities
-    tm = world.transaction_manager
+    tm = world.get_context(WorldTransaction)
     async with tm() as transaction:
         from datetime import datetime, timezone
 

--- a/packages/dam_archive/tests/test_extraction_system.py
+++ b/packages/dam_archive/tests/test_extraction_system.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from dam.core.transaction import WorldTransaction
 from dam.core.world import World
 from dam.functions import ecs_functions
 from dam.functions.mime_type_functions import set_content_mime_type
@@ -37,7 +38,7 @@ async def test_ingestion_with_memory_limit_and_filename(test_world_alpha: World,
     # 2. Register the archive
     register_cmd = RegisterLocalFileCommand(file_path=archive_path)
     entity_id = await world.dispatch_command(register_cmd).get_one_value()
-    tm = world.transaction_manager
+    tm = world.get_context(WorldTransaction)
     async with tm() as transaction:
         session = transaction.session
         await set_content_mime_type(session, entity_id, "application/zip")
@@ -79,7 +80,7 @@ async def test_ingestion_with_memory_limit(test_world_alpha: World, tmp_path: Pa
     # 2. Register the archive
     register_cmd = RegisterLocalFileCommand(file_path=archive_path)
     entity_id = await world.dispatch_command(register_cmd).get_one_value()
-    tm = world.transaction_manager
+    tm = world.get_context(WorldTransaction)
     async with tm() as transaction:
         session = transaction.session
         await set_content_mime_type(session, entity_id, "application/zip")
@@ -159,7 +160,7 @@ async def test_extract_archives(test_world_alpha: World, test_archives: tuple[Pa
     register_cmd_reg = RegisterLocalFileCommand(file_path=regular_archive_path)
     entity_id_reg = await world.dispatch_command(register_cmd_reg).get_one_value()
 
-    tm = world.transaction_manager
+    tm = world.get_context(WorldTransaction)
     async with tm() as transaction:
         session = transaction.session
         await set_content_mime_type(session, entity_id_reg, "application/zip")
@@ -231,7 +232,7 @@ async def test_skip_already_extracted(test_world_alpha: World, test_archives: tu
     register_cmd = RegisterLocalFileCommand(file_path=regular_archive_path)
     entity_id = await world.dispatch_command(register_cmd).get_one_value()
 
-    tm = world.transaction_manager
+    tm = world.get_context(WorldTransaction)
     async with tm() as transaction:
         session = transaction.session
         await set_content_mime_type(session, entity_id, "application/zip")

--- a/packages/dam_media_transcode/src/dam_media_transcode/functions/transcode_functions.py
+++ b/packages/dam_media_transcode/src/dam_media_transcode/functions/transcode_functions.py
@@ -5,6 +5,7 @@ from typing import Optional, Tuple, cast
 
 from dam.core.config import settings
 from dam.core.stages import SystemStage
+from dam.core.transaction import WorldTransaction
 from dam.core.world import World
 from dam.functions import (
     ecs_functions,
@@ -40,7 +41,7 @@ async def create_transcode_profile(
     """
     Creates a new transcoding profile as a conceptual asset.
     """
-    async with world.transaction_manager() as tx:
+    async with world.get_context(WorldTransaction)() as tx:
         session = tx.session
         # Check if profile with this name already exists
         stmt_existing = select(TranscodeProfileComponent).where(TranscodeProfileComponent.profile_name == profile_name)
@@ -137,7 +138,7 @@ async def get_transcode_profile_by_name_or_id(
     if session:
         return await _get(session)
     else:
-        async with world.transaction_manager() as tx:
+        async with world.get_context(WorldTransaction)() as tx:
             return await _get(tx.session)
 
 
@@ -179,7 +180,7 @@ async def apply_transcode_profile(
     Applies a transcoding profile to a source asset, creates a new asset for the
     transcoded file, and links them.
     """
-    async with world.transaction_manager() as tx:
+    async with world.get_context(WorldTransaction)() as tx:
         session = tx.session
         # 1. Get Transcode Profile
         _profile_entity, profile_component = await get_transcode_profile_by_name_or_id(
@@ -333,7 +334,7 @@ async def get_transcoded_variants_for_original(
     if session:
         return await _get(session)
     else:
-        async with world.transaction_manager() as tx:
+        async with world.get_context(WorldTransaction)() as tx:
             return await _get(tx.session)
 
 
@@ -357,5 +358,5 @@ async def get_assets_using_profile(
     if session:
         return await _get(session)
     else:
-        async with world.transaction_manager() as tx:
+        async with world.get_context(WorldTransaction)() as tx:
             return await _get(tx.session)

--- a/packages/dam_media_transcode/src/dam_media_transcode/systems/evaluation_systems.py
+++ b/packages/dam_media_transcode/src/dam_media_transcode/systems/evaluation_systems.py
@@ -2,6 +2,7 @@ import json
 from typing import Any, Dict, List, Optional, Tuple
 
 from dam.core.exceptions import EntityNotFoundError
+from dam.core.transaction import WorldTransaction
 from dam.core.world import World
 from dam.functions import ecs_functions, tag_functions
 from dam.models.core.entity import Entity
@@ -98,7 +99,7 @@ async def create_evaluation_run_concept(
     if session:
         return await _create(session)
     else:
-        async with world.transaction_manager() as tx:
+        async with world.get_context(WorldTransaction)() as tx:
             return await _create(tx.session)
 
 
@@ -128,7 +129,7 @@ async def get_evaluation_run_by_name_or_id(
     if session:
         return await _get(session)
     else:
-        async with world.transaction_manager() as tx:
+        async with world.get_context(WorldTransaction)() as tx:
             return await _get(tx.session)
 
 
@@ -155,7 +156,7 @@ async def execute_evaluation_run(
         c. Creates an EvaluationResultComponent for the transcoded asset.
     Returns a list of created EvaluationResultComponent instances.
     """
-    async with world.transaction_manager() as tx:
+    async with world.get_context(WorldTransaction)() as tx:
         session = tx.session
         try:
             _eval_run_entity, eval_run_comp = await get_evaluation_run_by_name_or_id(
@@ -375,5 +376,5 @@ async def get_evaluation_results(
     if session:
         return await _get(session)
     else:
-        async with world.transaction_manager() as tx:
+        async with world.get_context(WorldTransaction)() as tx:
             return await _get(tx.session)


### PR DESCRIPTION
- Added `get_context` and `has_context` methods to the `World` class to provide a type-safe way to access context providers.
- Renamed `transaction_manager` to `_transaction_manager` to make it a private attribute.
- Updated all references to `world.transaction_manager` to use the new `world.get_context(WorldTransaction)` method.