### PR TITLE
feat(archive): Refactor to use StreamProvider and improve handlers

### DIFF
--- a/packages/dam_archive/tests/test_archive.py
+++ b/packages/dam_archive/tests/test_archive.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from dam_archive.base import to_stream_provider
 from dam_archive.exceptions import InvalidPasswordError
 from dam_archive.main import open_archive
 
@@ -80,3 +81,29 @@ def test_open_protected_zip_with_incorrect_password(protected_zip_file: Path) ->
     with open(protected_zip_file, "rb") as f:
         with pytest.raises(InvalidPasswordError):
             open_archive(f, "application/zip", password="wrong_password")
+
+
+def test_open_zip_archive_with_stream_provider(dummy_zip_file: Path) -> None:
+    stream_provider = to_stream_provider(str(dummy_zip_file))
+    archive = open_archive(stream_provider, "application/zip")
+    assert archive is not None
+    assert archive.comment == "test comment"
+    files = archive.list_files()
+    file_names = [f.name for f in files]
+    assert "file1.txt" in file_names
+    assert "dir/file2.txt" in file_names
+
+    for f in files:
+        assert isinstance(f.modified_at, datetime.datetime)
+
+    member_info, f_in_zip = archive.open_file("file1.txt")
+    with f_in_zip:
+        assert f_in_zip.read() == b"content1"
+    assert member_info.name == "file1.txt"
+    assert member_info.size == 8
+
+    member_info, f_in_zip = archive.open_file("dir/file2.txt")
+    with f_in_zip:
+        assert f_in_zip.read() == b"content2"
+    assert member_info.name == "dir/file2.txt"
+    assert member_info.size == 8

--- a/packages/dam_archive/tests/test_sevenzip.py
+++ b/packages/dam_archive/tests/test_sevenzip.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import py7zr
 import pytest
 
+from dam_archive.base import to_stream_provider
 from dam_archive.exceptions import InvalidPasswordError, UnsupportedArchiveError
 from dam_archive.handlers.sevenzip import SevenZipArchiveHandler
 from dam_archive.main import open_archive
@@ -37,11 +38,11 @@ def test_unsupported_bcj2_archive_raises_error(bcj2_7z_archive: Path):
     """
     Tests that SevenZipArchiveHandler raises UnsupportedArchiveError for BCJ2-filtered archives.
     """
-    with pytest.raises(UnsupportedArchiveError):
-        # We test SevenZipArchiveHandler directly, as open_archive would fall back to the CLI handler.
-        with open(bcj2_7z_archive, "rb") as f:
-            handler = SevenZipArchiveHandler(f)
-            handler.close()
+    # We test SevenZipArchiveHandler directly, as open_archive would fall back to the CLI handler.
+    with open(bcj2_7z_archive, "rb") as f:
+        stream_provider = to_stream_provider(f)
+        with pytest.raises(UnsupportedArchiveError):
+            SevenZipArchiveHandler(stream_provider)
 
 
 @pytest.fixture

--- a/packages/dam_archive/tests/test_sevenzip_cli.py
+++ b/packages/dam_archive/tests/test_sevenzip_cli.py
@@ -2,19 +2,20 @@ from pathlib import Path
 
 import pytest
 
+from dam_archive.base import to_stream_provider
 from dam_archive.exceptions import InvalidPasswordError
 from dam_archive.handlers.sevenzip_cli import SevenZipCliArchiveHandler
 
 
 def test_open_regular_archive(regular_7z_archive: Path):
-    handler = SevenZipCliArchiveHandler(str(regular_7z_archive))
+    handler = SevenZipCliArchiveHandler(to_stream_provider(str(regular_7z_archive)))
     assert len(handler.list_files()) == 1
     assert handler.list_files()[0].name == "file.txt"
     handler.close()
 
 
 def test_open_protected_archive_with_password(protected_7z_archive: Path):
-    handler = SevenZipCliArchiveHandler(str(protected_7z_archive), password="password")
+    handler = SevenZipCliArchiveHandler(to_stream_provider(str(protected_7z_archive)), password="password")
     assert len(handler.list_files()) == 1
     assert handler.list_files()[0].name == "file.txt"
     handler.close()
@@ -22,18 +23,18 @@ def test_open_protected_archive_with_password(protected_7z_archive: Path):
 
 def test_open_protected_archive_with_wrong_password(protected_7z_archive: Path):
     with pytest.raises(InvalidPasswordError):
-        SevenZipCliArchiveHandler(str(protected_7z_archive), password="wrong_password")
+        SevenZipCliArchiveHandler(to_stream_provider(str(protected_7z_archive)), password="wrong_password")
 
 
 def test_open_bcj2_archive(bcj2_7z_archive: Path):
-    handler = SevenZipCliArchiveHandler(str(bcj2_7z_archive))
+    handler = SevenZipCliArchiveHandler(to_stream_provider(str(bcj2_7z_archive)))
     assert len(handler.list_files()) == 1
     assert handler.list_files()[0].name == "hello_x86"
     handler.close()
 
 
 def test_iter_files(regular_7z_archive: Path):
-    handler = SevenZipCliArchiveHandler(str(regular_7z_archive))
+    handler = SevenZipCliArchiveHandler(to_stream_provider(str(regular_7z_archive)))
     files = list(handler.iter_files())
     assert len(files) == 1
     member_info, file_handle = files[0]
@@ -45,7 +46,7 @@ def test_iter_files(regular_7z_archive: Path):
 
 
 def test_open_file(regular_7z_archive: Path):
-    handler = SevenZipCliArchiveHandler(str(regular_7z_archive))
+    handler = SevenZipCliArchiveHandler(to_stream_provider(str(regular_7z_archive)))
     member_info, file_handle = handler.open_file("file.txt")
     assert member_info.name == "file.txt"
     content = file_handle.read()


### PR DESCRIPTION
This commit refactors the `dam_archive` package to use a `StreamProvider` for more flexible and robust archive handling.

- A `StreamProvider` type (`Callable[[], BinaryIO]`) is introduced to provide a consistent way to get a fresh stream for an archive.
- The `open_archive` function and all `ArchiveHandler` subclasses are updated to use `StreamProvider`.
- `open_archive` now also accepts a `StreamProvider` directly, making the API more flexible.
- Validation in `SevenZipArchiveHandler`'s `__init__` is restored to ensure it fails fast on password or compression errors, reverting a previous optimization that was found to be a regression in behavior.
- A potential resource leak in `get_archive_asset_stream_handler` is fixed by ensuring the archive handler is closed when the member stream is closed.
- `systems.py` is updated to correctly call the refactored `open_archive` function.
- Missing type hints are added to fix `pyright` errors.