### PR TITLE
Refactor: Update component definitions for data integrity

### DIFF
--- a/packages/dam_archive/src/dam_archive/models/archive_member_component.py
+++ b/packages/dam_archive/src/dam_archive/models/archive_member_component.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional
 
 from dam.models.core import BaseComponent as Component
-from sqlalchemy import String
+from sqlalchemy import BigInteger, ForeignKey, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 
@@ -13,6 +13,6 @@ class ArchiveMemberComponent(Component):
 
     __tablename__ = "component_archive_member"
 
-    archive_entity_id: Mapped[int] = mapped_column(nullable=False)
+    archive_entity_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("entities.id"), nullable=False, index=True)
     path_in_archive: Mapped[str] = mapped_column(String(), nullable=False)
     modified_at: Mapped[Optional[datetime]] = mapped_column(nullable=True)

--- a/packages/dam_psp/src/dam_psp/models.py
+++ b/packages/dam_psp/src/dam_psp/models.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Optional
 
-from dam.models.core.base_component import UniqueComponent
-from sqlalchemy import Integer, String
+from dam.models.core.base_component import BaseComponent, UniqueComponent
+from sqlalchemy import BigInteger, ForeignKey, Integer, String
 from sqlalchemy.dialects.postgresql.json import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -43,14 +43,20 @@ class PspSfoRawMetadataComponent(UniqueComponent):
         )
 
 
-class CsoParentIsoComponent(UniqueComponent):
+class CsoParentIsoComponent(BaseComponent):
     """
     Links a virtual ISO entity back to the original CSO file entity from which it was derived.
     """
 
     __tablename__ = "component_cso_parent_iso"
 
-    cso_entity_id: Mapped[int] = mapped_column(Integer, index=True, unique=True)
+    cso_entity_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("entities.id"),
+        index=True,
+        unique=True,
+        nullable=False,
+    )
 
     def __repr__(self) -> str:
         return f"CsoParentIsoComponent(entity_id={self.entity_id}, cso_entity_id={self.cso_entity_id})"


### PR DESCRIPTION
- Adds a foreign key constraint to `ArchiveMemberComponent.archive_entity_id` to ensure it properly references an entity.
- Changes the base class of `CsoParentIsoComponent` from `UniqueComponent` to `BaseComponent`. This allows a single ISO entity to be associated with multiple CSO versions.
- Adds a foreign key constraint to `CsoParentIsoComponent.cso_entity_id`.