### PR TITLE
Refactor: Add reprocess_derived command to AssetOperation

### DIFF
--- a/packages/dam/src/dam/core/operations.py
+++ b/packages/dam/src/dam/core/operations.py
@@ -19,6 +19,7 @@ class AssetOperation:
     add_command_class: Type[EntityCommand[Any, Any]]
     check_command_class: Optional[Type[EntityCommand[bool, BaseSystemEvent]]] = None
     remove_command_class: Optional[Type[EntityCommand[None, BaseSystemEvent]]] = None
+    reprocess_derived_command_class: Optional[Type[EntityCommand[Any, Any]]] = None
 
     def get_supported_types(self) -> Dict[str, List[str]]:
         """

--- a/packages/dam_archive/src/dam_archive/commands/__init__.py
+++ b/packages/dam_archive/src/dam_archive/commands/__init__.py
@@ -4,6 +4,7 @@ from .ingestion import (
     CheckArchiveCommand,
     ClearArchiveComponentsCommand,
     IngestArchiveCommand,
+    ReissueArchiveMemberEventsCommand,
     TagArchivePartCommand,
 )
 from .password import (
@@ -22,6 +23,7 @@ __all__ = [
     "CheckArchiveCommand",
     "ClearArchiveComponentsCommand",
     "IngestArchiveCommand",
+    "ReissueArchiveMemberEventsCommand",
     "TagArchivePartCommand",
     "CheckArchivePasswordCommand",
     "RemoveArchivePasswordCommand",

--- a/packages/dam_archive/src/dam_archive/commands/ingestion.py
+++ b/packages/dam_archive/src/dam_archive/commands/ingestion.py
@@ -49,3 +49,12 @@ class ClearArchiveComponentsCommand(EntityCommand[None, BaseSystemEvent]):
     """
 
     pass
+
+
+@dataclass
+class ReissueArchiveMemberEventsCommand(EntityCommand[None, BaseSystemEvent]):
+    """
+    A command to re-issue NewEntityCreatedEvent events for all members of an existing archive.
+    """
+
+    pass

--- a/packages/dam_archive/src/dam_archive/operations.py
+++ b/packages/dam_archive/src/dam_archive/operations.py
@@ -1,14 +1,19 @@
 from dam.core.operations import AssetOperation
 
-from .commands import (
-    BindSplitArchiveCommand,
+from .commands.ingestion import (
     CheckArchiveCommand,
-    CheckArchivePasswordCommand,
-    CheckSplitArchiveBindingCommand,
     ClearArchiveComponentsCommand,
     IngestArchiveCommand,
+    ReissueArchiveMemberEventsCommand,
+)
+from .commands.password import (
+    CheckArchivePasswordCommand,
     RemoveArchivePasswordCommand,
     SetArchivePasswordCommand,
+)
+from .commands.split_archives import (
+    BindSplitArchiveCommand,
+    CheckSplitArchiveBindingCommand,
     UnbindSplitArchiveCommand,
 )
 
@@ -26,6 +31,7 @@ ingest_archive_operation = AssetOperation(
     add_command_class=IngestArchiveCommand,
     check_command_class=CheckArchiveCommand,
     remove_command_class=ClearArchiveComponentsCommand,
+    reprocess_derived_command_class=ReissueArchiveMemberEventsCommand,
 )
 
 set_archive_password_operation = AssetOperation(

--- a/packages/dam_archive/src/dam_archive/plugin.py
+++ b/packages/dam_archive/src/dam_archive/plugin.py
@@ -10,6 +10,7 @@ from .commands.ingestion import (
     CheckArchiveCommand,
     ClearArchiveComponentsCommand,
     IngestArchiveCommand,
+    ReissueArchiveMemberEventsCommand,
 )
 from .commands.password import (
     CheckArchivePasswordCommand,
@@ -34,6 +35,7 @@ from .systems.ingestion import (
     get_archive_asset_filenames_handler,
     get_archive_asset_stream_handler,
     ingest_archive_members_handler,
+    reissue_archive_member_events_handler,
 )
 from .systems.password import (
     check_archive_password_handler,
@@ -68,6 +70,7 @@ class ArchivePlugin(Plugin):
         world.register_system(check_archive_handler, command_type=CheckArchiveCommand)
         world.register_system(check_archive_password_handler, command_type=CheckArchivePasswordCommand)
         world.register_system(remove_archive_password_handler, command_type=RemoveArchivePasswordCommand)
+        world.register_system(reissue_archive_member_events_handler, command_type=ReissueArchiveMemberEventsCommand)
 
         # New binding systems
         world.register_system(bind_split_archive_handler, command_type=BindSplitArchiveCommand)

--- a/packages/dam_psp/src/dam_psp/__init__.py
+++ b/packages/dam_psp/src/dam_psp/__init__.py
@@ -11,9 +11,10 @@ from .commands import (
     ClearCsoIngestionCommand,
     ExtractPSPMetadataCommand,
     IngestCsoCommand,
+    ReissueVirtualIsoEventCommand,
     RemovePSPMetadataCommand,
 )
-from .operations import extract_psp_metadata_operation, ingest_cso_operation
+from .operations import decompress_cso_operation, extract_psp_metadata_operation
 from .systems import (
     check_cso_ingestion_handler,
     check_psp_metadata_handler,
@@ -21,6 +22,7 @@ from .systems import (
     get_virtual_iso_asset_stream_handler,
     ingest_cso_handler,
     psp_iso_metadata_extraction_command_handler_system,
+    reissue_virtual_iso_event_handler,
     remove_psp_metadata_handler,
 )
 
@@ -44,10 +46,11 @@ class PspPlugin(Plugin):
         world.register_system(check_cso_ingestion_handler, command_type=CheckCsoIngestionCommand)
         world.register_system(clear_cso_ingestion_handler, command_type=ClearCsoIngestionCommand)
         world.register_system(get_virtual_iso_asset_stream_handler, command_type=GetAssetStreamCommand)
+        world.register_system(reissue_virtual_iso_event_handler, command_type=ReissueVirtualIsoEventCommand)
 
         # Register Asset Operations
         world.register_asset_operation(extract_psp_metadata_operation)
-        world.register_asset_operation(ingest_cso_operation)
+        world.register_asset_operation(decompress_cso_operation)
 
 
-__all__ = ["PspPlugin", "psp_iso_functions", "extract_psp_metadata_operation"]
+__all__ = ["PspPlugin", "psp_iso_functions", "extract_psp_metadata_operation", "decompress_cso_operation"]

--- a/packages/dam_psp/src/dam_psp/commands.py
+++ b/packages/dam_psp/src/dam_psp/commands.py
@@ -66,3 +66,12 @@ class IngestCsoCommand(AnalysisCommand[None, BaseSystemEvent]):
             "mimetypes": ["application/x-ciso"],
             "extensions": [".cso"],
         }
+
+
+@dataclass
+class ReissueVirtualIsoEventCommand(EntityCommand[None, BaseSystemEvent]):
+    """
+    A command to re-issue a NewEntityCreatedEvent for the virtual ISO derived from a CSO file.
+    """
+
+    pass

--- a/packages/dam_psp/src/dam_psp/operations.py
+++ b/packages/dam_psp/src/dam_psp/operations.py
@@ -6,6 +6,7 @@ from .commands import (
     ClearCsoIngestionCommand,
     ExtractPSPMetadataCommand,
     IngestCsoCommand,
+    ReissueVirtualIsoEventCommand,
     RemovePSPMetadataCommand,
 )
 
@@ -17,10 +18,11 @@ extract_psp_metadata_operation = AssetOperation(
     remove_command_class=RemovePSPMetadataCommand,
 )
 
-ingest_cso_operation = AssetOperation(
-    name="ingest-cso",
-    description="Ingests a CSO file, creating a virtual ISO entity.",
+decompress_cso_operation = AssetOperation(
+    name="cso.decompress",
+    description="Decompresses a CSO file into a virtual ISO.",
     add_command_class=IngestCsoCommand,
     check_command_class=CheckCsoIngestionCommand,
+    reprocess_derived_command_class=ReissueVirtualIsoEventCommand,
     remove_command_class=ClearCsoIngestionCommand,
 )


### PR DESCRIPTION
This commit introduces a new `reprocess_derived_command_class` to the `AssetOperation` dataclass. This allows for a separate command to be executed when an asset has already been processed, enabling the reprocessing of its derived assets without re-running the initial ingestion logic.

Key changes:

-   **`dam`**:
    -   Modified `AssetOperation` to include the new optional `reprocess_derived_command_class` field.

-   **`dam_app`**:
    -   Updated the `add_assets` CLI command to check for the existence of an asset. If it exists, it now dispatches the `reprocess_derived_command_class` if available, otherwise it skips the asset.

-   **`dam_archive`**:
    -   Refactored the archive ingestion logic by creating a new `ReissueArchiveMemberEventsCommand` and a corresponding system handler.
    -   This new command is responsible for re-issuing `NewEntityCreatedEvent` events for all members of an existing archive.
    -   The `ingest_archive_operation` is updated to use this new command for reprocessing.
    -   The `get_archive_asset_stream_handler` now uses `get_first_non_none_value` to be more robust.

-   **`dam_psp`**:
    -   Implemented a similar pattern for CSO files by creating a `ReissueVirtualIsoEventCommand` and handler.
    -   This command re-issues the `NewEntityCreatedEvent` for the virtual ISO derived from a CSO file.
    -   The `ingest_cso_operation` has been renamed to `decompress_cso_operation` and updated to use the new reprocessing command.

-   **Tests**:
    -   Updated the `test_reingest_already_extracted_archive` test to reflect the new architecture, using the `ReissueArchiveMemberEventsCommand` and correctly handling on-demand stream retrieval.