### PR TITLE
refactor: Enforce top-level imports with ruff PLC0415

### DIFF
--- a/packages/dam/src/dam/commands/analysis_commands.py
+++ b/packages/dam/src/dam/commands/analysis_commands.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 
 from ..core.types import StreamProvider
 from ..system_events.base import BaseSystemEvent
+from .asset_commands import GetAssetStreamCommand
 from .core import EntityCommand, EventType, ResultType
 
 if TYPE_CHECKING:
@@ -33,8 +34,6 @@ class AnalysisCommand(EntityCommand[ResultType, EventType]):
         """
         if self.stream_provider:
             return self.stream_provider
-
-        from .asset_commands import GetAssetStreamCommand
 
         all_providers = await world.dispatch_command(GetAssetStreamCommand(entity_id=self.entity_id)).get_all_results()
 

--- a/packages/dam/src/dam/core/providers.py
+++ b/packages/dam/src/dam/core/providers.py
@@ -3,6 +3,9 @@
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator, List, Type
 
+from sqlalchemy import exists as sql_exists
+from sqlalchemy import select as sql_select
+
 from dam.core.contexts import ContextProvider
 from dam.core.transaction import WorldTransaction
 from dam.models.core.base_component import BaseComponent
@@ -23,9 +26,6 @@ class MarkedEntityListProvider(ContextProvider[List[Entity]]):
         """
         Queries for entities with the given marker component within a transaction.
         """
-        from sqlalchemy import exists as sql_exists
-        from sqlalchemy import select as sql_select
-
         stmt = sql_select(Entity).where(sql_exists().where(marker_component_type.entity_id == Entity.id))
         result = await transaction.session.execute(stmt)
         entities_to_process = list(result.scalars().all())

--- a/packages/dam/src/dam/core/world.py
+++ b/packages/dam/src/dam/core/world.py
@@ -223,7 +223,7 @@ def create_and_register_world(world_name: str, app_settings: Optional[Settings] 
 
     world = World(world_config=world_cfg)
 
-    from dam.plugins.core import CorePlugin
+    from dam.plugins.core import CorePlugin  # noqa: PLC0415
 
     world.add_plugin(CorePlugin())
 

--- a/packages/dam/src/dam/functions/ecs_functions.py
+++ b/packages/dam/src/dam/functions/ecs_functions.py
@@ -10,6 +10,7 @@ from dam.models.core.base_component import (
     Component,
 )
 from dam.models.core.entity import Entity
+from dam.models.hashes import ContentHashMD5Component, ContentHashSHA256Component
 
 # No longer need to import specific components if REGISTERED_COMPONENT_TYPES is comprehensive
 
@@ -253,8 +254,6 @@ async def find_entity_id_by_hash(
     Returns the Entity ID or None if not found.
     Converts hex string hash_value to bytes before querying.
     """
-    from dam.models import ContentHashMD5Component, ContentHashSHA256Component  # Moved import here
-
     hash_bytes: bytes
     try:
         hash_bytes = bytes.fromhex(hash_value)
@@ -309,8 +308,6 @@ async def find_entity_by_content_hash(
     If multiple entities somehow have the same content hash (shouldn't happen for CAS),
     it will return the first one found.
     """
-    from dam.models import ContentHashMD5Component, ContentHashSHA256Component
-
     component_to_query: Type[Component]
     if hash_type.lower() == "sha256":
         component_to_query = ContentHashSHA256Component

--- a/packages/dam/tests/test_hashing_systems.py
+++ b/packages/dam/tests/test_hashing_systems.py
@@ -1,3 +1,4 @@
+import hashlib
 from io import BytesIO
 
 import pytest
@@ -38,8 +39,6 @@ async def test_add_hashes_from_stream_system(test_world_alpha: World) -> None:
     async with tm() as transaction:
         md5_comp = await ecs_functions.get_component(transaction.session, entity_id, ContentHashMD5Component)
         assert md5_comp is not None
-        import hashlib
-
         assert md5_comp.hash_value == hashlib.md5(data).digest()
 
         sha256_comp = await ecs_functions.get_component(transaction.session, entity_id, ContentHashSHA256Component)

--- a/packages/dam_app/src/dam_app/cli/assets.py
+++ b/packages/dam_app/src/dam_app/cli/assets.py
@@ -24,6 +24,7 @@ from dam_fs.commands import (
     RegisterLocalFileCommand,
     StoreAssetsCommand,
 )
+from rich import print_json
 from rich.console import Console
 from rich.table import Table
 from rich.traceback import Traceback
@@ -342,8 +343,6 @@ async def show_entity(
         if not components_dict:
             typer.secho(f"No components found for entity {entity_id}", fg=typer.colors.YELLOW)
             return
-        from rich import print_json
-
         print_json(data=components_dict)
 
 

--- a/packages/dam_app/src/dam_app/main.py
+++ b/packages/dam_app/src/dam_app/main.py
@@ -6,6 +6,7 @@ import typer
 from dam.core import config as app_config
 from dam.core.logging_config import setup_logging
 from dam.core.transaction import WorldTransaction
+from dam.core.transaction_manager import TransactionManager
 from dam.core.world import (
     clear_world_registry,
     create_and_register_all_worlds_from_settings,
@@ -55,8 +56,6 @@ async def setup_db(ctx: typer.Context):
         raise typer.Exit(code=1)
     typer.echo(f"Setting up database for world: '{target_world.name}'...")
     try:
-        from dam.core.transaction_manager import TransactionManager
-
         transaction_manager = target_world.get_context(WorldTransaction)
         assert isinstance(transaction_manager, TransactionManager)
         await transaction_manager.create_db_and_tables()

--- a/packages/dam_app/src/dam_app/systems/auto_tagging_system.py
+++ b/packages/dam_app/src/dam_app/systems/auto_tagging_system.py
@@ -4,7 +4,10 @@ from typing import Annotated
 from dam.core.systems import system
 from dam.core.transaction import WorldTransaction
 from dam.core.world import World
+from dam_fs.functions import file_operations as file_operations_module
 from dam_sire.resource import SireResource
+
+from dam_app.functions import tagging_functions as tagging_functions_module
 
 from ..commands import AutoTagEntityCommand
 
@@ -24,10 +27,6 @@ async def auto_tag_entity_command_handler(
     session = transaction.session
     entity = cmd.entity
     logger.info(f"Handling AutoTagEntityCommand for entity {entity.id}")
-
-    from dam_fs.functions import file_operations as file_operations_module
-
-    from dam_app.functions import tagging_functions as tagging_functions_module
 
     image_path = await file_operations_module.get_file_path_for_entity(world, transaction, entity.id)
     if not image_path:

--- a/packages/dam_app/tests/test_cli.py
+++ b/packages/dam_app/tests/test_cli.py
@@ -1,19 +1,31 @@
+import io
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from dam.commands.asset_commands import GetAssetFilenamesCommand, GetMimeTypeCommand
 from dam.commands.core import BaseCommand
 from dam.core.config import Settings
+from dam.core.operations import AssetOperation
+from dam.core.types import CallableStreamProvider
 from dam.core.world import World
+from dam.system_events.entity_events import NewEntityCreatedEvent
+from dam_archive.commands import CheckArchiveCommand, IngestArchiveCommand
+from dam_fs.commands import FindEntityByFilePropertiesCommand, RegisterLocalFileCommand
 from pytest import CaptureFixture
+
+from dam_app.cli.assets import add_assets, check_data, process_entities, remove_data
+from dam_app.commands import CheckExifMetadataCommand, ExtractExifMetadataCommand
+from dam_app.main import (
+    cli_list_worlds,
+    create_and_register_all_worlds_from_settings,
+)
 
 
 @pytest.mark.serial
 def test_cli_list_worlds(settings_override: Settings, capsys: CaptureFixture[Any]):
     """Test the list-worlds command."""
-    from dam_app.main import cli_list_worlds, create_and_register_all_worlds_from_settings
-
     # Ensure worlds are registered
     create_and_register_all_worlds_from_settings(app_settings=settings_override)
 
@@ -27,20 +39,7 @@ def test_cli_list_worlds(settings_override: Settings, capsys: CaptureFixture[Any
 @pytest.mark.asyncio
 async def test_add_assets_with_recursive_process_option(capsys: CaptureFixture[Any], tmp_path: Path):
     """Test the add_assets command with the --process option for recursive processing."""
-    import io
-
-    from dam.commands.asset_commands import GetAssetFilenamesCommand, GetMimeTypeCommand
-
     # 1. Setup
-    from dam.core.operations import AssetOperation
-    from dam.core.types import CallableStreamProvider
-    from dam.system_events.entity_events import NewEntityCreatedEvent
-    from dam_archive.commands import CheckArchiveCommand, IngestArchiveCommand
-    from dam_fs.commands import FindEntityByFilePropertiesCommand, RegisterLocalFileCommand
-
-    from dam_app.cli.assets import add_assets
-    from dam_app.commands import CheckExifMetadataCommand, ExtractExifMetadataCommand
-
     mock_world = MagicMock(spec=World)
 
     # Configure the mock to return specific operations
@@ -151,15 +150,7 @@ async def test_add_assets_with_recursive_process_option(capsys: CaptureFixture[A
 @pytest.mark.asyncio
 async def test_add_assets_with_extension_process_option(capsys: CaptureFixture[Any], tmp_path: Path):
     """Test the add_assets command with the --process option based on file extension."""
-    from dam.commands.asset_commands import GetAssetFilenamesCommand, GetMimeTypeCommand
-
     # 1. Setup
-    from dam.core.operations import AssetOperation
-    from dam_archive.commands import CheckArchiveCommand, IngestArchiveCommand
-    from dam_fs.commands import FindEntityByFilePropertiesCommand, RegisterLocalFileCommand
-
-    from dam_app.cli.assets import add_assets
-
     mock_world = MagicMock(spec=World)
 
     # Configure the mock to return a specific operation
@@ -224,16 +215,7 @@ async def test_add_assets_with_extension_process_option(capsys: CaptureFixture[A
 @pytest.mark.asyncio
 async def test_add_assets_with_command_name_process_option(capsys: CaptureFixture[Any], tmp_path: Path):
     """Test the add_assets command with the --process option using only the command name."""
-    from dam.commands.asset_commands import GetAssetFilenamesCommand, GetMimeTypeCommand
-
     # 1. Setup
-    from dam.core.operations import AssetOperation
-    from dam_archive.commands import CheckArchiveCommand, IngestArchiveCommand
-    from dam_fs.commands import FindEntityByFilePropertiesCommand, RegisterLocalFileCommand
-
-    from dam_app.cli.assets import add_assets
-    from dam_app.commands import CheckExifMetadataCommand, ExtractExifMetadataCommand
-
     # Reset cache before test to ensure dynamic logic is tested
     ExtractExifMetadataCommand._cached_extensions = None  # type: ignore [protected-access]
 
@@ -339,10 +321,6 @@ async def test_add_assets_with_command_name_process_option(capsys: CaptureFixtur
 @pytest.mark.asyncio
 async def test_process_entities_command(capsys: CaptureFixture[Any]):
     """Test the 'process' CLI command."""
-    from dam.core.operations import AssetOperation
-
-    from dam_app.cli.assets import process_entities
-
     # 1. Setup
     mock_world = MagicMock(spec=World)
     mock_add_command = MagicMock()
@@ -380,10 +358,6 @@ async def test_process_entities_command(capsys: CaptureFixture[Any]):
 @pytest.mark.asyncio
 async def test_remove_data_command(capsys: CaptureFixture[Any]):
     """Test the 'remove-data' CLI command."""
-    from dam.core.operations import AssetOperation
-
-    from dam_app.cli.assets import remove_data
-
     # 1. Setup
     mock_world = MagicMock(spec=World)
     mock_remove_command = MagicMock()
@@ -414,10 +388,6 @@ async def test_remove_data_command(capsys: CaptureFixture[Any]):
 @pytest.mark.asyncio
 async def test_check_data_command(capsys: CaptureFixture[Any]):
     """Test the 'check-data' CLI command."""
-    from dam.core.operations import AssetOperation
-
-    from dam_app.cli.assets import check_data
-
     # 1. Setup
     mock_world = MagicMock(spec=World)
     mock_check_command = MagicMock()

--- a/packages/dam_app/tests/test_cli_character.py
+++ b/packages/dam_app/tests/test_cli_character.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from pathlib import Path  # Missing import
 from typing import Optional  # For asset_sha256 type hint
 
@@ -7,6 +8,9 @@ from dam.core.world import World
 from dam.functions import character_functions as character_service
 from dam.functions import ecs_functions as ecs_service
 from dam.models.conceptual import CharacterConceptComponent, EntityCharacterLinkComponent
+from dam.models.hashes import ContentHashSHA256Component
+from dam.models.metadata.content_length_component import ContentLengthComponent
+from dam_fs.commands import RegisterLocalFileCommand
 from dam_fs.models import FilenameComponent  # For creating dummy assets
 
 
@@ -88,10 +92,6 @@ async def test_cli_character_apply_list_find(  # Made async
     asset_filename = "asset_for_char_link_service.txt"
     async with test_world_alpha.get_context(WorldTransaction)() as tx:
         session = tx.session
-        from datetime import datetime, timezone
-
-        from dam.models.metadata.content_length_component import ContentLengthComponent
-
         asset_entity = await ecs_service.create_entity(session)
         await ecs_service.add_component_to_entity(
             session,
@@ -192,8 +192,6 @@ async def test_cli_character_apply_with_identifiers(  # Made async
     # The stdout assertions have been removed from it in a previous step.
 
     # 1. Add an asset via service calls to ensure it's properly ingested with hashes
-    from dam_fs.commands import RegisterLocalFileCommand
-
     add_command = RegisterLocalFileCommand(file_path=sample_image_a)
     await test_world_alpha.dispatch_command(add_command).get_all_results()
     # No add_result or exit_code to check here, assume success if no exceptions
@@ -209,8 +207,6 @@ async def test_cli_character_apply_with_identifiers(  # Made async
         assert len(entities) == 1
         asset_entity = entities[0]
         asset_id_for_test = asset_entity.id
-
-        from dam.models.hashes import ContentHashSHA256Component
 
         sha_comp = await ecs_service.get_component(session, asset_id_for_test, ContentHashSHA256Component)
         assert sha_comp is not None

--- a/packages/dam_archive/tests/test_archive_commands.py
+++ b/packages/dam_archive/tests/test_archive_commands.py
@@ -1,11 +1,14 @@
 import asyncio
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Annotated, List
 
 import pytest
 from dam.core.transaction import WorldTransaction
 from dam.core.world import World
+from dam.models.metadata.content_length_component import ContentLengthComponent
 from dam_fs.commands import RegisterLocalFileCommand
+from dam_fs.models import FilenameComponent
 from sqlalchemy import select
 
 from dam_archive.commands import (
@@ -153,11 +156,6 @@ async def test_manual_create_and_unbind_workflow(
     # 1. Setup: Manually create part entities
     tm = world.get_context(WorldTransaction)
     async with tm() as transaction:
-        from datetime import datetime, timezone
-
-        from dam.models.metadata.content_length_component import ContentLengthComponent
-        from dam_fs.models import FilenameComponent
-
         for i in range(1, 3):
             entity = await transaction.create_entity()
             entity_ids.append(entity.id)

--- a/packages/dam_archive/tests/test_extraction_system.py
+++ b/packages/dam_archive/tests/test_extraction_system.py
@@ -1,4 +1,5 @@
 import io
+import zipfile
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -31,7 +32,6 @@ async def test_ingestion_with_memory_limit_and_filename(test_world_alpha: World,
     file_content = b"a" * (1024 * 1024)  # 1 MB
     file_name_in_archive = "large_file.txt"
     archive_path = tmp_path / "large_archive.zip"
-    import zipfile
 
     with zipfile.ZipFile(archive_path, "w") as zf:
         zf.writestr(file_name_in_archive, file_content)
@@ -74,7 +74,6 @@ async def test_ingestion_with_memory_limit(test_world_alpha: World, tmp_path: Pa
     # 1. Create a test archive with a single file
     file_content = b"a" * (1024 * 1024)  # 1 MB
     archive_path = tmp_path / "large_archive.zip"
-    import zipfile
 
     with zipfile.ZipFile(archive_path, "w") as zf:
         zf.writestr("large_file.txt", file_content)

--- a/packages/dam_fs/src/dam_fs/functions/file_operations.py
+++ b/packages/dam_fs/src/dam_fs/functions/file_operations.py
@@ -1,6 +1,8 @@
 import asyncio
 import datetime
 import logging
+import mimetypes
+import subprocess
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -56,9 +58,6 @@ def get_mime_type(filepath: Path) -> str:
     """
     if not filepath.is_file():
         raise FileNotFoundError(f"File not found: {filepath}")
-
-    import mimetypes
-    import subprocess
 
     mime_type = None
     try:

--- a/packages/dam_fs/src/dam_fs/resources/file_operations_resource.py
+++ b/packages/dam_fs/src/dam_fs/resources/file_operations_resource.py
@@ -1,3 +1,6 @@
+from ..functions import file_operations as ops
+
+
 class FileOperationsResource:
     """
     A resource that provides access to file system operations.
@@ -15,9 +18,6 @@ class FileOperationsResource:
         Initializes the FileOperationsResource by binding methods to the
         functions from the `dam_fs.functions.file_operations` module.
         """
-        # Import functions from the file_operations functions module
-        from ..functions import file_operations as ops
-
         # Make functions available as methods of this resource instance
         self.get_file_properties = ops.get_file_properties
         self.get_mime_type = ops.get_mime_type

--- a/packages/dam_media_image/src/dam_media_image/systems/image_systems.py
+++ b/packages/dam_media_image/src/dam_media_image/systems/image_systems.py
@@ -7,6 +7,8 @@ from dam.core.world import World
 from dam.utils.hash_utils import HashAlgorithm, calculate_hashes_from_stream
 from dam_fs.functions import file_operations
 from dam_fs.models.filename_component import FilenameComponent
+from PIL import Image
+from sqlalchemy import select as sql_select
 
 from ..commands import FindSimilarImagesCommand
 from ..events import ImageAssetDetected
@@ -67,7 +69,6 @@ async def handle_find_similar_images_command(
             )
 
         potential_matches: list[dict[str, Any]] = []
-        from sqlalchemy import select as sql_select
 
         if input_phash_obj:
             all_phashes_stmt = sql_select(ImagePerceptualPHashComponent)
@@ -185,8 +186,6 @@ async def process_image_metadata_system(
     """
     Listens for an image asset being detected and extracts its metadata.
     """
-    from PIL import Image
-
     logger.info(f"Processing image metadata for entity {event.entity.id}")
 
     try:

--- a/packages/dam_semantic/src/dam_semantic/__init__.py
+++ b/packages/dam_semantic/src/dam_semantic/__init__.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from dam.core.plugin import Plugin
+from dam_media_audio.commands import AudioSearchCommand
 
+from . import systems
 from .commands import SemanticSearchCommand
 
 if TYPE_CHECKING:
@@ -11,6 +13,20 @@ if TYPE_CHECKING:
 
 
 from dam_media_image.plugin import ImagePlugin
+
+if TYPE_CHECKING:
+    from dam_sire.resource import SireResource
+    from sentence_transformers import SentenceTransformer
+    from sire.core.runtime_resource_user.pytorch_module import TorchModuleWrapper
+
+try:
+    from dam_sire.resource import SireResource
+    from sentence_transformers import SentenceTransformer
+    from sire.core.runtime_resource_user.pytorch_module import TorchModuleWrapper
+
+    sire_installed = True
+except ImportError:
+    sire_installed = False
 
 
 class SemanticPlugin(Plugin):
@@ -25,10 +41,6 @@ class SemanticPlugin(Plugin):
         # Add dependent plugins
         world.add_plugin(ImagePlugin())
 
-        from dam_media_audio.commands import AudioSearchCommand
-
-        from . import systems
-
         world.register_system(
             systems.handle_semantic_search_command,
             command_type=SemanticSearchCommand,
@@ -37,17 +49,10 @@ class SemanticPlugin(Plugin):
         world.register_system(systems.generate_embeddings_system)
 
         # Register the SentenceTransformer model type with the SireResource
-        try:
-            from dam_sire.resource import SireResource
-            from sentence_transformers import SentenceTransformer
-            from sire.core.runtime_resource_user.pytorch_module import TorchModuleWrapper
-
+        if sire_installed:
             sire_resource = world.get_resource(SireResource)
             if sire_resource:
                 sire_resource.register_model_type(SentenceTransformer, TorchModuleWrapper)
-        except ImportError:
-            # dam_sire or sentence_transformers is not installed
-            pass
 
 
 __all__ = ["SemanticPlugin"]

--- a/packages/dam_semantic/tests/conftest.py
+++ b/packages/dam_semantic/tests/conftest.py
@@ -1,14 +1,13 @@
 import pytest
+from dam_sire.resource import SireResource
+from dam_test_utils.fixtures import MockSentenceTransformer
+from sire.core.runtime_resource_user.pytorch_module import TorchModuleWrapper
 
 pytest_plugins = ["dam_test_utils.fixtures"]
 
 
 @pytest.fixture
 def sire_resource():
-    from dam_sire.resource import SireResource
-    from dam_test_utils.fixtures import MockSentenceTransformer
-    from sire.core.runtime_resource_user.pytorch_module import TorchModuleWrapper
-
     resource = SireResource()
     resource.register_model_type(MockSentenceTransformer, TorchModuleWrapper)
     return resource

--- a/packages/dam_source/src/dam_source/systems/web_asset_systems.py
+++ b/packages/dam_source/src/dam_source/systems/web_asset_systems.py
@@ -1,5 +1,8 @@
+import json
 import logging
+from datetime import datetime
 from typing import Any, Dict, Optional
+from urllib.parse import urlparse
 
 from dam.core.systems import system
 from dam.core.transaction import WorldTransaction
@@ -41,8 +44,6 @@ async def handle_ingest_web_asset_command(
         website_name = cmd.metadata_payload.get("website_name") if cmd.metadata_payload else None
         if not website_name:
             try:
-                from urllib.parse import urlparse
-
                 parsed_url = urlparse(cmd.website_identifier_url)
                 website_name = parsed_url.netloc.replace("www.", "")
             except Exception:
@@ -84,8 +85,6 @@ async def handle_ingest_web_asset_command(
         upload_date_str = cmd.metadata_payload.get("upload_date")
         if upload_date_str:
             try:
-                from datetime import datetime
-
                 web_source_data["upload_date"] = datetime.fromisoformat(upload_date_str.replace("Z", "+00:00"))
             except ValueError:
                 logger.warning(f"Could not parse upload_date string '{upload_date_str}' for {cmd.source_url}")
@@ -96,8 +95,6 @@ async def handle_ingest_web_asset_command(
         web_source_data["raw_metadata_dump"] = cmd.metadata_payload
 
     if cmd.tags:
-        import json
-
         web_source_data["tags_json"] = json.dumps(cmd.tags)
 
     valid_web_source_fields = {

--- a/packages/dam_test_utils/src/dam_test_utils/fixtures.py
+++ b/packages/dam_test_utils/src/dam_test_utils/fixtures.py
@@ -22,12 +22,15 @@ from dam.core.config import Settings
 from dam.core.config import settings as global_settings
 from dam.core.database import DatabaseManager
 from dam.core.transaction import WorldTransaction
+from dam.core.transaction_manager import TransactionManager
 from dam.core.world import (
     World,
     clear_world_registry,
     create_and_register_world,
 )
 from dam.models.core.base_class import Base
+from PIL import Image
+from scipy.io.wavfile import write as write_wav  # type: ignore[import]
 from sqlalchemy.ext.asyncio import AsyncSession
 
 _original_settings_values: Dict[str, Any] = {}
@@ -125,7 +128,6 @@ async def _setup_world(
 
     world = create_and_register_world(world_name, app_settings=settings_override_fixture)
     world.add_resource(world, World)
-    from dam.core.transaction_manager import TransactionManager
 
     transaction_manager = world.get_context(WorldTransaction)
     assert isinstance(transaction_manager, TransactionManager)
@@ -140,8 +142,6 @@ async def _setup_world(
 
 async def _teardown_world_async(world: World) -> None:
     if world and world.has_context(WorldTransaction):
-        from dam.core.transaction_manager import TransactionManager
-
         transaction_manager = world.get_context(WorldTransaction)
         assert isinstance(transaction_manager, TransactionManager)
         db_mngr = transaction_manager.db_manager
@@ -236,8 +236,6 @@ def temp_asset_file(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def temp_image_file(tmp_path: Path) -> Path:
-    from PIL import Image
-
     file_path = tmp_path / "test_image.png"
     img = Image.new("RGB", (60, 30), color="red")
     img.save(file_path)
@@ -246,8 +244,6 @@ def temp_image_file(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def sample_image_a(tmp_path: Path) -> Path:
-    from PIL import Image
-
     file_path = tmp_path / "sample_A.png"
     img = Image.new("RGB", (2, 1), color=(128, 128, 128))
     img.save(file_path)
@@ -271,9 +267,6 @@ def sample_video_file_placeholder(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def sample_audio_file_placeholder(tmp_path: Path) -> Path:
-    import numpy as np
-    from scipy.io.wavfile import write as write_wav  # type: ignore[import]
-
     file_path = tmp_path / "sample_audio_placeholder.wav"
     samplerate = 44100
     duration = 1
@@ -287,8 +280,6 @@ def sample_audio_file_placeholder(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def sample_gif_file_placeholder(tmp_path: Path) -> Path:
-    from PIL import Image
-
     file_path = tmp_path / "sample_gif_placeholder.gif"
     img = Image.new("RGB", (1, 1), color=(255, 255, 255))
     img.save(file_path)
@@ -297,9 +288,6 @@ def sample_gif_file_placeholder(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def sample_wav_file(tmp_path: Path) -> Path:
-    import numpy as np
-    from scipy.io.wavfile import write as write_wav  # type: ignore[import]
-
     file_path = tmp_path / "sample.wav"
     samplerate = 48000
     duration = 1

--- a/packages/domarkx/src/domarkx/action/exec_doc.py
+++ b/packages/domarkx/src/domarkx/action/exec_doc.py
@@ -1,5 +1,6 @@
 import asyncio
 import pathlib
+import re
 from datetime import datetime
 from typing import Annotated, Any, Optional
 
@@ -45,8 +46,6 @@ async def aexec_doc(
             f.write(expanded_content)
     else:
         if not overwrite:
-            import re
-
             # Check for timestamp with optional letters at the end of the stem
             match = re.search(r"(_\d{8}_\d{6})([A-Z]*)$", doc.stem)
 

--- a/packages/domarkx/src/domarkx/action/init.py
+++ b/packages/domarkx/src/domarkx/action/init.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 from typing import Optional
 
@@ -42,12 +43,8 @@ def init_project(
             s = os.path.join(default_template_path, item)
             d = os.path.join(project_path, item)
             if os.path.isdir(s):
-                import shutil
-
                 shutil.copytree(s, d, False, dirs_exist_ok=True)
             else:
-                import shutil
-
                 shutil.copy2(s, d)
 
     print(f"Project initialized at: {project_path}")

--- a/packages/domarkx/src/domarkx/agents/resume_funcall_assistant_agent.py
+++ b/packages/domarkx/src/domarkx/agents/resume_funcall_assistant_agent.py
@@ -4,6 +4,7 @@ from typing import (
     List,
     Sequence,
     Union,
+    cast,
 )
 
 from autogen_agentchat.agents import AssistantAgent
@@ -17,6 +18,7 @@ from autogen_core import CancellationToken, FunctionCall
 from autogen_core.models import (
     AssistantMessage,
     CreateResult,
+    RequestUsage,
 )
 from rich.console import Console
 
@@ -64,9 +66,6 @@ class ResumeFunCallAssistantAgent(AssistantAgent):
             and all(isinstance(item, FunctionCall) for item in model_context_messages[-1].content)
         ):
             fun_model_result = model_context_messages[-1]
-            from typing import cast
-
-            from autogen_core.models import RequestUsage
 
             create_result = CreateResult(
                 finish_reason="function_calls",

--- a/packages/domarkx/src/domarkx/autogen_session.py
+++ b/packages/domarkx/src/domarkx/autogen_session.py
@@ -9,7 +9,7 @@ from autogen_ext.models._utils.parse_r1_content import parse_r1_content
 
 from domarkx.agents.resume_funcall_assistant_agent import ResumeFunCallAssistantAgent
 from domarkx.session import Session
-from domarkx.utils.chat_doc_parser import MarkdownLLMParser, Message
+from domarkx.utils.chat_doc_parser import MarkdownLLMParser, Message, append_message
 from domarkx.utils.code_execution import execute_code_block
 from domarkx.utils.markdown_utils import CodeBlock
 
@@ -81,8 +81,6 @@ class AutoGenSession(Session):
         self.messages = messages
 
     def append_new_messages(self, new_state: dict[str, Any]) -> None:
-        from domarkx.utils.chat_doc_parser import append_message
-
         for message in new_state["llm_context"]["messages"][len(self.messages) :]:
             content = ""
             if "content" in message:

--- a/packages/domarkx/src/domarkx/tool_call/run_tool_code/tool.py
+++ b/packages/domarkx/src/domarkx/tool_call/run_tool_code/tool.py
@@ -4,6 +4,10 @@ from typing import Any, Callable
 
 from rich.console import Console
 
+from domarkx.tools.apply_diff import apply_diff_tool
+from domarkx.tools.attempt_completion import attempt_completion_tool
+from domarkx.tools.tool_factory import default_tool_factory
+
 from ...utils.no_border_rich_tracebacks import NoBorderTraceback
 
 REGISTERED_TOOLS: dict[str, Callable[..., Any]] = {}
@@ -90,11 +94,6 @@ def format_assistant_response(tool_name: str, tool_result: str) -> str:
 
 
 def register_tools() -> None:
-    from domarkx.tools.tool_factory import default_tool_factory
-
-    from ...tools.apply_diff import apply_diff_tool
-    from ...tools.attempt_completion import attempt_completion_tool
-
     register_tool("apply_diff")(apply_diff_tool)
     register_tool("attempt_completion")(attempt_completion_tool)
     register_tool("execute_command")(default_tool_factory.get_tool("tool_execute_command"))

--- a/packages/domarkx/src/domarkx/tools/tool_factory.py
+++ b/packages/domarkx/src/domarkx/tools/tool_factory.py
@@ -11,6 +11,8 @@ from rich.console import Console
 from rich.logging import RichHandler
 from rich.traceback import Traceback
 
+from domarkx.utils.code_execution import execute_code_block
+
 
 class ToolError(Exception):
     """Custom exception for tool-related errors."""
@@ -183,8 +185,6 @@ class ToolFactory:
         """
         Creates a tool from a string of Python code.
         """
-        from domarkx.utils.code_execution import execute_code_block
-
         local_namespace: dict[str, Any] = {}
         execute_code_block(code, global_vars=globals(), local_vars=local_namespace)
 

--- a/packages/domarkx/tests/test_md_template_conformance.py
+++ b/packages/domarkx/tests/test_md_template_conformance.py
@@ -1,4 +1,5 @@
 import glob
+from typing import List
 
 from typer.testing import CliRunner
 
@@ -19,7 +20,6 @@ def test_all_templates_md_conformance() -> None:
         md_files = glob.glob("**/*.md", recursive=True)
         assert md_files, "No .md files found in project"
         parser = MarkdownLLMParser()
-        from typing import List
 
         all_errors: List[str] = []
         for md_path in md_files:

--- a/packages/sire/src/sire/core/commit_object_auto_device_manage.py
+++ b/packages/sire/src/sire/core/commit_object_auto_device_manage.py
@@ -1,5 +1,6 @@
 from typing import Any, NewType, Optional, TypeVar
 
+import accelerate.hooks
 import diffusers
 import torch
 
@@ -66,8 +67,6 @@ class CommitAutoManage(CommitABC[T]):
 
     def revert(self, base_object: T) -> None:
         if self.am and isinstance(self.am.user, TorchModuleWrapper) and self.am.user.use_accelerate:
-            import accelerate.hooks
-
             if isinstance(base_object, torch.nn.Module):
                 accelerate.hooks.remove_hook_from_module(base_object, recurse=True)
                 self.am.user.use_accelerate = False

--- a/packages/sire/src/sire/core/patch_able_module.py
+++ b/packages/sire/src/sire/core/patch_able_module.py
@@ -143,10 +143,8 @@ class ControlFlowPatchAbleModuleMixin(Generic[T]):
         return self.patcher_module_inst.patcher_module_map
 
     def patcher_module_init(self) -> None:
-        import torch
-
         self.patcher_module_inst = ControlFlowPatchAbleModule[T]()
-        self.patcher_module_dict = torch.nn.ModuleDict()
+        self.patcher_module_dict = nn.ModuleDict()
 
     def patcher_module_add(self, path_type: str, patch_object: ControlFlowPatchModuleMixin):
         patch_name = patch_object.get_patch_module_name()
@@ -163,9 +161,7 @@ class ControlFlowPatchAbleModuleMixin(Generic[T]):
         self.patcher_module_update()
 
     def patcher_module_update(self):
-        import torch
-
-        patcher_module_dict = torch.nn.ModuleDict()
+        patcher_module_dict = nn.ModuleDict()
 
         def add_patch_object(patch_object):
             patch_name = patch_object.get_patch_module_name()

--- a/packages/sire/tests/test_api.py
+++ b/packages/sire/tests/test_api.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 
 import sire
+from sire.core.runtime_resource_management import AutoManageHook
 
 
 # A simple model for testing
@@ -108,7 +109,6 @@ def test_automanage_hook() -> None:
         pytest.skip("CUDA not available, skipping GPU part of the test")
 
     model = SimpleModel()
-    from sire.core.runtime_resource_management import AutoManageHook
 
     hook = AutoManageHook.manage_module(model)
     hook.am.user.runtime_resource_pool = sire.get_resource_management().get_resource_pool(  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ target-version = "py312"
 docstring-code-format = true
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I001", "I","F401", "E402"]
+select = ["E", "F", "W", "I001", "I", "F401", "E402", "PLC0415"]
 ignore = ["E501", "F841", "F811"]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
This commit enables the `PLC0415` rule in the root `pyproject.toml` to enforce that all imports are at the top level of the file, improving code style and consistency.

Following the configuration change, this commit also refactors the entire codebase to move all local imports to the top level of their respective files. This addresses all `PLC0415` violations reported by the linter.

In one specific case (`dam/core/world.py`), a local import was necessary to avoid a circular dependency. This has been addressed by ignoring the linting error for that line with a `# noqa: PLC0415` comment.