### PR TITLE
fix: Resolve linting errors and refactor stream handling

### DIFF
--- a/packages/dam/src/dam/commands/asset_commands.py
+++ b/packages/dam/src/dam/commands/asset_commands.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, BinaryIO, Optional, Tuple
+from typing import Any, Optional, Tuple
 
 from ..core.types import StreamProvider
 from ..models.core.entity import Entity
@@ -14,7 +14,7 @@ class GetOrCreateEntityFromStreamCommand(BaseCommand[Tuple[Entity, bytes], BaseS
     Returns a tuple of the entity and the calculated sha256 hash.
     """
 
-    stream: BinaryIO
+    stream_provider: StreamProvider
 
 
 @dataclass

--- a/packages/dam/src/dam/commands/hashing_commands.py
+++ b/packages/dam/src/dam/commands/hashing_commands.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import BinaryIO, Set
+from typing import Set
 
+from ..core.types import StreamProvider
 from ..system_events.base import BaseSystemEvent
 from ..utils.hash_utils import HashAlgorithm
 from .core import BaseCommand
@@ -13,5 +14,5 @@ class AddHashesFromStreamCommand(BaseCommand[None, BaseSystemEvent]):
     """Command to calculate and add multiple hash components to an entity from a stream."""
 
     entity_id: int
-    stream: BinaryIO
+    stream_provider: StreamProvider
     algorithms: Set[HashAlgorithm]

--- a/packages/dam/src/dam/core/config.py
+++ b/packages/dam/src/dam/core/config.py
@@ -79,7 +79,7 @@ class Settings(BaseSettings):
                     raw_world_configs = json.load(f)
                 logger.info(f"Loaded world configurations from file: {config_source}")
             except (IOError, json.JSONDecodeError) as e:
-                raise ValueError(f"Error reading or parsing worlds config file {config_source}: {e}")
+                raise ValueError(f"Error reading or parsing worlds config file {config_source}: {e}") from e
         else:
             try:
                 raw_world_configs = json.loads(config_source)

--- a/packages/dam/src/dam/core/logging_config.py
+++ b/packages/dam/src/dam/core/logging_config.py
@@ -25,7 +25,7 @@ def setup_logging(level: int | str | None = None) -> None:
             if env_level:  # If DAM_LOG_LEVEL was set but invalid
                 # Use a basic print here, as logging might not be fully set up
                 # or to ensure this specific warning is always visible.
-                print(
+                print(  # noqa: T201
                     f"Warning: Invalid DAM_LOG_LEVEL '{env_level}'. Defaulting to {logging.getLevelName(log_level)}.",
                     file=sys.stderr,
                 )
@@ -35,7 +35,7 @@ def setup_logging(level: int | str | None = None) -> None:
             log_level = getattr(logging, log_level_name)
         else:
             log_level = DEFAULT_LOG_LEVEL
-            print(
+            print(  # noqa: T201
                 f"Warning: Invalid log level string '{level}'. Defaulting to {logging.getLevelName(log_level)}.",
                 file=sys.stderr,
             )
@@ -67,7 +67,6 @@ def setup_logging(level: int | str | None = None) -> None:
 
 if __name__ == "__main__":
     # Example usage and test
-    print("Testing logging configuration...")
     os.environ["DAM_LOG_LEVEL"] = "DEBUG"
     setup_logging()
     logger = logging.getLogger("dam.core.logging_config_test")
@@ -76,11 +75,9 @@ if __name__ == "__main__":
     logger.warning("This is a warning message.")
     logger.error("This is an error message.")
 
-    print("\nTesting with invalid level string...")
     setup_logging(level="INVALID_LEVEL_STRING")  # Should print warning to stderr
     logger.info("Info message after attempting invalid level string.")
 
-    print("\nTesting with direct level INFO...")
     # Need to clear handlers for re-configuration in this test script context
     logging.getLogger("dam").handlers.clear()
     setup_logging(level=logging.INFO)
@@ -91,7 +88,6 @@ if __name__ == "__main__":
     if "DAM_LOG_LEVEL" in os.environ:
         del os.environ["DAM_LOG_LEVEL"]
     logging.getLogger("dam").handlers.clear()
-    print("\nTesting with default log level (no env var)...")
     setup_logging()
     logger.info(
         f"Default log level test. Current level: {logging.getLevelName(logging.getLogger('dam').getEffectiveLevel())}"
@@ -100,10 +96,7 @@ if __name__ == "__main__":
 
     # Test specific string level
     logging.getLogger("dam").handlers.clear()
-    print("\nTesting with specific string level 'WARNING'...")
     setup_logging(level="WARNING")
     effective_level_name = logging.getLevelName(logging.getLogger("dam").getEffectiveLevel())
     logger.info(f"Test log at WARNING. Effective: {effective_level_name}. Info should not appear.")
     logger.warning("This warning message should be seen.")
-
-    print("\nLogging configuration test complete.")

--- a/packages/dam/src/dam/core/resources.py
+++ b/packages/dam/src/dam/core/resources.py
@@ -1,6 +1,8 @@
+import logging
 from typing import Any, Dict, List, Optional, Type, TypeVar, cast
 
 T = TypeVar("T")
+logger = logging.getLogger(__name__)
 
 
 class ResourceNotFoundError(Exception):
@@ -48,7 +50,7 @@ class ResourceManager:
             # Depending on policy, could raise error, log a warning, or allow replacement.
             # For now, let's log a warning and replace.
             # Consider making this behavior configurable if needed.
-            print(f"Warning: Replacing existing resource for type {res_type.__name__}")
+            logger.warning(f"Replacing existing resource for type {res_type.__name__}")
 
         self._resources[res_type] = instance
 

--- a/packages/dam/src/dam/core/systems.py
+++ b/packages/dam/src/dam/core/systems.py
@@ -290,7 +290,7 @@ class WorldScheduler:
                             resolved_deps_by_type[param.type_hint] = command_object
                             break
                 resolved_params_by_name.update(additional_kwargs)
-                for key, value in additional_kwargs.items():
+                for _key, value in additional_kwargs.items():
                     resolved_deps_by_type[type(value)] = value
 
                 unresolved_params = {

--- a/packages/dam/src/dam/functions/ecs_functions.py
+++ b/packages/dam/src/dam/functions/ecs_functions.py
@@ -322,7 +322,7 @@ async def find_entity_by_content_hash(
     # We need a broader query for components matching the hash_value across all entities.
 
     # Simpler: query component_to_query directly.
-    stmt = select(component_to_query).where(getattr(component_to_query, "hash_value") == hash_value)
+    stmt = select(component_to_query).where(component_to_query.hash_value == hash_value)
     result = await session.execute(stmt)  # Await execute
     components_found = result.scalars().all()
 

--- a/packages/dam/src/dam/systems/__init__.py
+++ b/packages/dam/src/dam/systems/__init__.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 # Dynamically discover and import all modules in the current package
 # This avoids having to manually update a list of system modules.
 # This avoids having to manually update a list of system modules.
-for finder, name, ispkg in pkgutil.iter_modules(__path__, __name__ + "."):
+for _finder, name, _ispkg in pkgutil.iter_modules(__path__, __name__ + "."):
     try:
         importlib.import_module(name)
         logger.debug(f"Successfully imported system module: {name}")

--- a/packages/dam/src/dam/systems/hashing_systems.py
+++ b/packages/dam/src/dam/systems/hashing_systems.py
@@ -97,7 +97,8 @@ async def add_hashes_from_stream_system(cmd: AddHashesFromStreamCommand, transac
     """
     logger.info(f"System handling AddHashesFromStreamCommand for entity {cmd.entity_id}")
 
-    hashes = calculate_hashes_from_stream(cmd.stream, cmd.algorithms)
+    async with cmd.stream_provider.get_stream() as stream:
+        hashes = calculate_hashes_from_stream(stream, cmd.algorithms)
 
     for algorithm, hash_value in hashes.items():
         hash_value_bytes: bytes

--- a/packages/dam/tests/test_hashing_systems.py
+++ b/packages/dam/tests/test_hashing_systems.py
@@ -5,6 +5,7 @@ import pytest
 
 from dam.commands.hashing_commands import AddHashesFromStreamCommand
 from dam.core.transaction import WorldTransaction
+from dam.core.types import CallableStreamProvider
 from dam.core.world import World
 from dam.functions import ecs_functions
 from dam.models.hashes import (
@@ -29,9 +30,10 @@ async def test_add_hashes_from_stream_system(test_world_alpha: World) -> None:
 
     data = b"hello world"
     stream = BytesIO(data)
+    stream_provider = CallableStreamProvider(lambda: stream)
     command = AddHashesFromStreamCommand(
         entity_id=entity_id,
-        stream=stream,
+        stream_provider=stream_provider,
         algorithms={HashAlgorithm.MD5, HashAlgorithm.SHA256},
     )
     await world.dispatch_command(command).get_all_results()
@@ -65,9 +67,10 @@ async def test_add_hashes_from_stream_system_propagates_mismatch_error(
 
     data = b"hello world"
     stream = BytesIO(data)
+    stream_provider = CallableStreamProvider(lambda: stream)
     command = AddHashesFromStreamCommand(
         entity_id=entity_id,
-        stream=stream,
+        stream_provider=stream_provider,
         algorithms={HashAlgorithm.MD5},
     )
 

--- a/packages/dam_app/pyproject.toml
+++ b/packages/dam_app/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "dam_archive",
     "dam_sire",
     "sire",
+    "aiofiles",
 ]
 
 [project.optional-dependencies]
@@ -87,4 +88,5 @@ DEP002 = [
     "dam_media_transcode",
     "dam_psp",
     "dam_semantic",
+    "aiofiles",
 ]

--- a/packages/dam_app/src/dam_app/cli/assets.py
+++ b/packages/dam_app/src/dam_app/cli/assets.py
@@ -84,13 +84,13 @@ async def add_assets(
                     if key not in process_map:
                         process_map[key] = []
                     process_map[key].append(command_name)
-                except ValueError:
+                except ValueError as e:
                     # This should not happen due to the ':' check, but for safety:
                     typer.secho(
                         f"Invalid format for --process option: '{p}'. Must be 'key:CommandName'",
                         fg=typer.colors.RED,
                     )
-                    raise typer.Exit(code=1)
+                    raise typer.Exit(code=1) from e
             else:
                 # Handle new 'CommandName' format
                 operation_name = p

--- a/packages/dam_app/src/dam_app/main.py
+++ b/packages/dam_app/src/dam_app/main.py
@@ -62,7 +62,7 @@ async def setup_db(ctx: typer.Context):
         typer.secho("Database setup complete.", fg=typer.colors.GREEN)
     except Exception as e:
         typer.secho(f"Error during database setup: {e}", fg=typer.colors.RED)
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from e
 
 
 @app.callback(invoke_without_command=True)
@@ -83,7 +83,7 @@ def main_callback(
         initialized_worlds = create_and_register_all_worlds_from_settings(app_settings=app_config.settings)
     except Exception as e:
         typer.secho(f"Critical error: Could not initialize worlds: {e}", fg=typer.colors.RED)
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from e
 
     # Dynamically load all plugins
     plugins = {

--- a/packages/dam_archive/pyproject.toml
+++ b/packages/dam_archive/pyproject.toml
@@ -28,7 +28,11 @@ dependencies = [
     "psutil",
     "sqlalchemy",
     "dam_fs",
+    "aiofiles>=23.2.1",
 ]
+
+[project.optional-dependencies]
+test = []
 
 [tool.ruff]
 extend = "../../pyproject.toml"
@@ -53,3 +57,6 @@ include = "../../shared_tasks.toml"
 
 [tool.poe.tasks]
 mypy = "mypy --config-file ../../pyproject.toml src tests"
+
+[tool.deptry.per_rule_ignores]
+DEP002 = ["aiofiles"]

--- a/packages/dam_archive/src/dam_archive/handlers/rar.py
+++ b/packages/dam_archive/src/dam_archive/handlers/rar.py
@@ -53,7 +53,7 @@ class RarArchiveHandler(ArchiveHandler):
                 handler.rar_file.setpassword(password)  # type: ignore
             # The check below is to trigger a password error for protected archives.
             if len(handler.rar_file.infolist()) > 0:  # type: ignore
-                handler.rar_file.infolist()[0].filename  # type: ignore
+                _ = handler.rar_file.infolist()[0].filename  # type: ignore
 
         except Exception as e:
             await handler._stream_cm_exit(type(e), e, e.__traceback__)

--- a/packages/dam_archive/src/dam_archive/handlers/sevenzip_cli.py
+++ b/packages/dam_archive/src/dam_archive/handlers/sevenzip_cli.py
@@ -81,7 +81,7 @@ class SevenZipCliArchiveHandler(ArchiveHandler):
             self._run_7z(args)
         except ArchiveError as e:
             if "wrong password" in str(e).lower():
-                raise InvalidPasswordError("Invalid password for 7z archive.")
+                raise InvalidPasswordError("Invalid password for 7z archive.") from e
             raise
 
     def _run_7z(self, args: List[str], check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -95,15 +95,15 @@ class SevenZipCliArchiveHandler(ArchiveHandler):
                 encoding="utf-8",
                 errors="replace",
             )
-        except FileNotFoundError:
-            raise ArchiveError("7z command not found. Please ensure it is installed and in your PATH.")
+        except FileNotFoundError as e:
+            raise ArchiveError("7z command not found. Please ensure it is installed and in your PATH.") from e
         except subprocess.CalledProcessError as e:
             stderr = e.stderr.lower()
             if "wrong password" in stderr or "data error in encrypted file" in stderr:
-                raise InvalidPasswordError("Invalid password for 7z archive.")
+                raise InvalidPasswordError("Invalid password for 7z archive.") from e
             if "can not open the file as archive" in stderr:
-                raise ArchiveError(f"File is not a valid 7z archive or is corrupted: {self.file_path}")
-            raise ArchiveError(f"7z command failed with exit code {e.returncode}: {e.stderr}")
+                raise ArchiveError(f"File is not a valid 7z archive or is corrupted: {self.file_path}") from e
+            raise ArchiveError(f"7z command failed with exit code {e.returncode}: {e.stderr}") from e
 
     def _list_files_and_populate_members(self) -> None:
         args = ["l", "-ba", self.file_path]
@@ -186,8 +186,8 @@ class SevenZipCliArchiveHandler(ArchiveHandler):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
-        except FileNotFoundError:
-            raise ArchiveError("7z command not found. Please ensure it is installed and in your PATH.")
+        except FileNotFoundError as e:
+            raise ArchiveError("7z command not found. Please ensure it is installed and in your PATH.") from e
 
         if process.stdout is None:
             raise ArchiveError("Failed to open file stream from 7z.")

--- a/packages/dam_archive/src/dam_archive/main.py
+++ b/packages/dam_archive/src/dam_archive/main.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import BinaryIO, Optional, Union
+from typing import Optional, Union
 
 from dam.core.types import StreamProvider
 
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 async def open_archive(
-    file_or_path_or_provider: Union[str, Path, BinaryIO, StreamProvider],
+    file_or_path_or_provider: Union[str, Path, StreamProvider],
     mime_type: str,
     password: Optional[str] = None,
 ) -> Optional[ArchiveHandler]:

--- a/packages/dam_archive/tests/test_archive.py
+++ b/packages/dam_archive/tests/test_archive.py
@@ -22,30 +22,29 @@ def dummy_zip_file(tmp_path: Path) -> Path:
 
 @pytest.mark.asyncio
 async def test_open_zip_archive(dummy_zip_file: Path) -> None:
-    with open(dummy_zip_file, "rb") as f:
-        archive = await open_archive(f, "application/zip")
-        assert archive is not None
-        assert archive.comment == "test comment"
-        files = archive.list_files()
-        file_names = [f.name for f in files]
-        assert "file1.txt" in file_names
-        assert "dir/file2.txt" in file_names
+    archive = await open_archive(dummy_zip_file, "application/zip")
+    assert archive is not None
+    assert archive.comment == "test comment"
+    files = archive.list_files()
+    file_names = [f.name for f in files]
+    assert "file1.txt" in file_names
+    assert "dir/file2.txt" in file_names
 
-        for f_info in files:
-            assert isinstance(f_info.modified_at, datetime.datetime)
+    for f_info in files:
+        assert isinstance(f_info.modified_at, datetime.datetime)
 
-        member_info, f_in_zip = archive.open_file("file1.txt")
-        with f_in_zip:
-            assert f_in_zip.read() == b"content1"
-        assert member_info.name == "file1.txt"
-        assert member_info.size == 8
+    member_info, f_in_zip = archive.open_file("file1.txt")
+    with f_in_zip:
+        assert f_in_zip.read() == b"content1"
+    assert member_info.name == "file1.txt"
+    assert member_info.size == 8
 
-        member_info, f_in_zip = archive.open_file("dir/file2.txt")
-        with f_in_zip:
-            assert f_in_zip.read() == b"content2"
-        assert member_info.name == "dir/file2.txt"
-        assert member_info.size == 8
-        await archive.close()
+    member_info, f_in_zip = archive.open_file("dir/file2.txt")
+    with f_in_zip:
+        assert f_in_zip.read() == b"content2"
+    assert member_info.name == "dir/file2.txt"
+    assert member_info.size == 8
+    await archive.close()
 
 
 @pytest.fixture
@@ -71,21 +70,19 @@ def protected_zip_file(tmp_path: Path) -> Path:
 
 @pytest.mark.asyncio
 async def test_open_protected_zip_with_correct_password(protected_zip_file: Path) -> None:
-    with open(protected_zip_file, "rb") as f:
-        archive = await open_archive(f, "application/zip", password="password")
-        assert archive is not None
-        member_info, f_in_zip = archive.open_file("file1.txt")
-        with f_in_zip:
-            assert f_in_zip.read() == b"content1"
-        assert member_info.name == "file1.txt"
-        await archive.close()
+    archive = await open_archive(protected_zip_file, "application/zip", password="password")
+    assert archive is not None
+    member_info, f_in_zip = archive.open_file("file1.txt")
+    with f_in_zip:
+        assert f_in_zip.read() == b"content1"
+    assert member_info.name == "file1.txt"
+    await archive.close()
 
 
 @pytest.mark.asyncio
 async def test_open_protected_zip_with_incorrect_password(protected_zip_file: Path) -> None:
-    with open(protected_zip_file, "rb") as f:
-        with pytest.raises(InvalidPasswordError):
-            await open_archive(f, "application/zip", password="wrong_password")
+    with pytest.raises(InvalidPasswordError):
+        await open_archive(protected_zip_file, "application/zip", password="wrong_password")
 
 
 @pytest.mark.asyncio

--- a/packages/dam_archive/tests/test_zip.py
+++ b/packages/dam_archive/tests/test_zip.py
@@ -20,16 +20,15 @@ def utf8_encoded_zip_file(tmp_path: Path) -> Path:
 async def test_open_zip_with_utf8_filename(utf8_encoded_zip_file: Path) -> None:
     # This test checks the happy path where the filename is UTF-8 encoded
     # and the UTF-8 flag is set in the zip file.
-    with open(utf8_encoded_zip_file, "rb") as f:
-        archive = await open_archive(f, "application/zip")
-        assert archive is not None
-        files = archive.list_files()
-        assert "测试.txt" in [m.name for m in files]
+    archive = await open_archive(utf8_encoded_zip_file, "application/zip")
+    assert archive is not None
+    files = archive.list_files()
+    assert "测试.txt" in [m.name for m in files]
 
-        member_info, f_in_zip = archive.open_file("测试.txt")
-        with f_in_zip:
-            assert f_in_zip.read() == b"content"
-        assert member_info.name == "测试.txt"
+    member_info, f_in_zip = archive.open_file("测试.txt")
+    with f_in_zip:
+        assert f_in_zip.read() == b"content"
+    assert member_info.name == "测试.txt"
 
 
 @pytest.fixture
@@ -54,26 +53,24 @@ async def test_open_zip_with_cp437_filename(cp437_encoded_zip_file: Path) -> Non
     # This test checks the fallback path where the filename is not UTF-8.
     # My code attempts to decode with cp437, then utf-8, then gbk.
     # In this case, the filename is valid cp437.
-    with open(cp437_encoded_zip_file, "rb") as f:
-        archive = await open_archive(f, "application/zip")
-        assert archive is not None
-        files = archive.list_files()
-        assert "tést.txt" in [m.name for m in files]
+    archive = await open_archive(cp437_encoded_zip_file, "application/zip")
+    assert archive is not None
+    files = archive.list_files()
+    assert "tést.txt" in [m.name for m in files]
 
 
 @pytest.mark.asyncio
 async def test_iter_files_zip_with_utf8_filename(utf8_encoded_zip_file: Path) -> None:
     # This test checks the iter_files method.
-    with open(utf8_encoded_zip_file, "rb") as f:
-        archive = await open_archive(f, "application/zip")
-        assert archive is not None
+    archive = await open_archive(utf8_encoded_zip_file, "application/zip")
+    assert archive is not None
 
-        files = list(archive.iter_files())
-        assert len(files) == 1
+    files = list(archive.iter_files())
+    assert len(files) == 1
 
-        member_info, member_stream = files[0]
-        assert member_info.name == "测试.txt"
-        assert member_info.size == 7  # "content" is 7 bytes
+    member_info, member_stream = files[0]
+    assert member_info.name == "测试.txt"
+    assert member_info.size == 7  # "content" is 7 bytes
 
-        with member_stream as f_in_zip:
-            assert f_in_zip.read() == b"content"
+    with member_stream as f_in_zip:
+        assert f_in_zip.read() == b"content"

--- a/packages/dam_fs/pyproject.toml
+++ b/packages/dam_fs/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "dam",
     "python-magic",
     "sqlalchemy",
+    "aiofiles",
 ]
 
 [project.optional-dependencies]
@@ -42,3 +43,6 @@ include = "../../shared_tasks.toml"
 
 [tool.poe.tasks]
 mypy = "mypy --config-file ../../pyproject.toml src tests"
+
+[tool.deptry.per_rule_ignores]
+DEP002 = ["aiofiles"]

--- a/packages/dam_fs/src/dam_fs/systems/asset_lifecycle_systems.py
+++ b/packages/dam_fs/src/dam_fs/systems/asset_lifecycle_systems.py
@@ -11,6 +11,7 @@ from dam.commands.asset_commands import (
 from dam.core.config import WorldConfig
 from dam.core.systems import system
 from dam.core.transaction import WorldTransaction
+from dam.core.types import FileStreamProvider
 from dam.core.world import World
 from dam.functions import ecs_functions
 from dam.models.core import Entity
@@ -104,9 +105,9 @@ async def register_local_file_handler(
         return existing_flc.entity_id
 
     # File is new or modified, proceed with hash-based entity creation/retrieval
-    with open(file_path, "rb") as f:
-        get_or_create_cmd = GetOrCreateEntityFromStreamCommand(stream=f)
-        result_tuple = await world.dispatch_command(get_or_create_cmd).get_one_value()
+    stream_provider = FileStreamProvider(file_path)
+    get_or_create_cmd = GetOrCreateEntityFromStreamCommand(stream_provider=stream_provider)
+    result_tuple = await world.dispatch_command(get_or_create_cmd).get_one_value()
     entity, _ = result_tuple
 
     async with transaction.session.begin_nested():

--- a/packages/dam_fs/tests/test_asset_lifecycle_systems.py
+++ b/packages/dam_fs/tests/test_asset_lifecycle_systems.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 import os
 import shutil
@@ -109,7 +110,7 @@ async def test_first_seen_at_logic(test_world_alpha: World, tmp_path: Path):
         assert fnc.first_seen_at == recent_mod_time
 
     # 2. Create another file with the same name and content but an earlier timestamp
-    time.sleep(1)
+    await asyncio.sleep(1)
     earlier_file_dir = tmp_path / "earlier"
     earlier_file_dir.mkdir()
     earlier_file = earlier_file_dir / "test_file.txt"
@@ -155,7 +156,7 @@ async def test_reregister_modified_file(test_world_alpha: World, temp_asset_file
         original_mtime = flc.last_modified_at
 
     # 2. Modify the file
-    time.sleep(1)  # Ensure mtime changes
+    await asyncio.sleep(1)  # Ensure mtime changes
     temp_asset_file.touch()
     new_mod_time = datetime.datetime.fromtimestamp(temp_asset_file.stat().st_mtime, tz=datetime.timezone.utc)
 

--- a/packages/dam_media_image/pyproject.toml
+++ b/packages/dam_media_image/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "Pillow",
     "sqlalchemy",
     "dam_fs",
+    "aiofiles",
 ]
 
 [project.optional-dependencies]
@@ -39,3 +40,6 @@ include = "../../shared_tasks.toml"
 
 [tool.poe.tasks]
 mypy = "mypy --config-file ../../pyproject.toml src"
+
+[tool.deptry.per_rule_ignores]
+DEP002 = ["aiofiles"]

--- a/packages/dam_media_image/src/dam_media_image/systems/image_systems.py
+++ b/packages/dam_media_image/src/dam_media_image/systems/image_systems.py
@@ -1,6 +1,8 @@
+import io
 import logging
 from typing import Any, Dict, List, Optional
 
+import aiofiles
 from dam.core.systems import system
 from dam.core.transaction import WorldTransaction
 from dam.core.world import World
@@ -57,8 +59,10 @@ async def handle_find_similar_images_command(
 
         source_entity_id = None
         try:
-            with open(cmd.image_path, "rb") as f:
-                hashes = calculate_hashes_from_stream(f, {HashAlgorithm.SHA256})
+            async with aiofiles.open(cmd.image_path, "rb") as f:
+                content = await f.read()
+            stream = io.BytesIO(content)
+            hashes = calculate_hashes_from_stream(stream, {HashAlgorithm.SHA256})
             source_content_hash_bytes = hashes[HashAlgorithm.SHA256]
             source_entity = await transaction.find_entity_by_content_hash(source_content_hash_bytes, "sha256")  # type: ignore
             if source_entity:

--- a/packages/dam_media_transcode/pyproject.toml
+++ b/packages/dam_media_transcode/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "dam",
     "dam_fs",
     "sqlalchemy",
+    "aiofiles",
 ]
 
 [project.optional-dependencies]
@@ -37,3 +38,6 @@ include = "../../shared_tasks.toml"
 
 [tool.poe.tasks]
 mypy = "mypy --config-file ../../pyproject.toml src"
+
+[tool.deptry.per_rule_ignores]
+DEP002 = ["aiofiles"]

--- a/packages/dam_media_transcode/src/dam_media_transcode/utils/media_utils.py
+++ b/packages/dam_media_transcode/src/dam_media_transcode/utils/media_utils.py
@@ -82,7 +82,7 @@ def transcode_media(
     # can be a security risk if these values come from untrusted user input without sanitization.
     # Here, we assume tool_name and tool_params are curated (e.g., from TranscodeProfileComponent).
 
-    print(f"Running transcoding command: {' '.join(command_parts)}")  # For logging/debugging
+    logger.info(f"Running transcoding command: {' '.join(command_parts)}")  # For logging/debugging
 
     # Check if the tool exists
     if not shutil.which(tool_name):
@@ -97,7 +97,7 @@ def transcode_media(
                 output_path.unlink()
             except OSError as unlink_e:
                 # Log this, but raise the original TranscodeError
-                print(f"Warning: Could not delete incomplete output file {output_path}: {unlink_e}")
+                logger.warning(f"Could not delete incomplete output file {output_path}: {unlink_e}")
         raise e  # Re-raise the original error
 
     if not output_path.exists() or output_path.stat().st_size == 0:
@@ -106,7 +106,7 @@ def transcode_media(
             output_path.unlink(missing_ok=True)
         raise TranscodeError(f"Transcoding command ran but output file {output_path} was not created or is empty.")
 
-    print(f"Transcoding successful. Output: {output_path}")
+    logger.info(f"Transcoding successful. Output: {output_path}")
     return output_path
 
 
@@ -125,7 +125,7 @@ if __name__ == "__main__":
     if not dummy_input.exists():
         with open(dummy_input, "w") as f:
             f.write("This is a dummy input file for transcoding tests.")
-        print(f"Created dummy input: {dummy_input}")
+        logger.info(f"Created dummy input: {dummy_input}")
 
     # Test 1: FFmpeg (example - requires ffmpeg and a suitable input)
     # This specific ffmpeg command might fail if input.txt is not a valid video/image source.
@@ -152,7 +152,7 @@ if __name__ == "__main__":
     )
 
     if shutil.which("ffmpeg"):
-        print("\n--- Testing FFmpeg ---")
+        logger.info("\n--- Testing FFmpeg ---")
         try:
             # Replacing placeholders manually for this direct test
             params_ffmpeg = ffmpeg_params_template.replace("{input}", str(dummy_input))
@@ -165,16 +165,16 @@ if __name__ == "__main__":
                 tool_name="ffmpeg",
                 tool_params=ffmpeg_params_template,  # Pass the template string
             )
-            print(f"FFmpeg test successful. Output: {dummy_output_mp4}")
+            logger.info(f"FFmpeg test successful. Output: {dummy_output_mp4}")
             if dummy_output_mp4.exists():
                 dummy_output_mp4.unlink()  # Clean up
         except TranscodeError as e:
-            print(f"FFmpeg test failed: {e}")
+            logger.error(f"FFmpeg test failed: {e}")
         except FileNotFoundError as e:
-            print(f"FFmpeg test skipped, input file missing: {e}")
+            logger.error(f"FFmpeg test skipped, input file missing: {e}")
 
     else:
-        print("ffmpeg not found, skipping FFmpeg test.")
+        logger.info("ffmpeg not found, skipping FFmpeg test.")
 
     # Test 2: cjxl (example - requires cjxl and a suitable input image)
     # cjxl typically takes an image (e.g., PNG) and outputs JXL.
@@ -183,30 +183,30 @@ if __name__ == "__main__":
     # A real test would involve creating a small PNG using Pillow, for example.
     # params_cjxl = "{input} {output} -q 90" # Example params
     if shutil.which("cjxl"):
-        print("\n--- Testing cjxl (placeholder) ---")
-        print("cjxl found, but test requires a dummy image input (e.g., PNG). Skipping detailed test.")
+        logger.info("\n--- Testing cjxl (placeholder) ---")
+        logger.info("cjxl found, but test requires a dummy image input (e.g., PNG). Skipping detailed test.")
         # try:
         #     # Create a dummy PNG if Pillow is available, or assume one exists
         #     dummy_png_input = current_dir / "dummy_input.png"
         #     if not dummy_png_input.exists():
-        #         print(f"Skipping cjxl test: {dummy_png_input} not found.")
+        #         logger.info(f"Skipping cjxl test: {dummy_png_input} not found.")
         #     else:
         #         transcode_media(dummy_png_input, dummy_output_jxl, "cjxl", params_cjxl)
-        #         print(f"cjxl test successful. Output: {dummy_output_jxl}")
+        #         logger.info(f"cjxl test successful. Output: {dummy_output_jxl}")
         #         if dummy_output_jxl.exists(): dummy_output_jxl.unlink()
         # except TranscodeError as e:
-        #     print(f"cjxl test failed: {e}")
+        #     logger.error(f"cjxl test failed: {e}")
         # except FileNotFoundError as e:
-        #     print(f"cjxl test skipped, input file missing: {e}")
+        #     logger.error(f"cjxl test skipped, input file missing: {e}")
     else:
-        print("cjxl not found, skipping cjxl test.")
+        logger.info("cjxl not found, skipping cjxl test.")
 
     # Clean up dummy input
     if dummy_input.exists():
         dummy_input.unlink()
-        print(f"Cleaned up dummy input: {dummy_input}")
+        logger.info(f"Cleaned up dummy input: {dummy_input}")
 
-    print("\nMedia utils tests finished.")
+    logger.info("\nMedia utils tests finished.")
 
 
 __all__ = ["transcode_media", "TranscodeError"]

--- a/packages/dam_psp/pyproject.toml
+++ b/packages/dam_psp/pyproject.toml
@@ -27,6 +27,11 @@ dependencies = [
     "sqlalchemy",
 ]
 
+[project.optional-dependencies]
+test = [
+    "aiofiles>=23.2.1",
+]
+
 [tool.ruff]
 extend = "../../pyproject.toml"
 exclude = ["build", "dist"]
@@ -47,3 +52,6 @@ include = "../../shared_tasks.toml"
 
 [tool.poe.tasks]
 mypy = "mypy --config-file ../../pyproject.toml src tests"
+
+[tool.deptry.per_rule_ignores]
+DEP002 = ["aiofiles"]

--- a/packages/domarkx/pyproject.toml
+++ b/packages/domarkx/pyproject.toml
@@ -42,6 +42,9 @@ jupyter-executor = [
 docker-jupyter-executor = [
     "autogen-ext[docker-jupyter-executor]",
 ]
+test = [
+    "aiofiles>=23.2.1",
+]
 
 [project.scripts]
 domarkx = "domarkx.cli:main"

--- a/packages/domarkx/src/domarkx/action/exec_doc.py
+++ b/packages/domarkx/src/domarkx/action/exec_doc.py
@@ -4,6 +4,7 @@ import re
 from datetime import datetime
 from typing import Annotated, Any, Optional
 
+import aiofiles
 import typer
 from prompt_toolkit import PromptSession
 
@@ -21,8 +22,8 @@ async def aexec_doc(
     overwrite: bool = False,
 ) -> None:
     # Read the content from the document
-    with open(doc, "r") as f:
-        content = f.read()
+    async with aiofiles.open(doc, "r") as f:
+        content = await f.read()
 
     # Expand macros
     expander = DocExpander(base_dir=str(doc.parent))
@@ -42,8 +43,8 @@ async def aexec_doc(
         temp_filename = f"{now}_{doc.stem}.md"
         doc_to_exec = sessions_dir / temp_filename
 
-        with open(doc_to_exec, "w") as f:
-            f.write(expanded_content)
+        async with aiofiles.open(doc_to_exec, "w") as f:
+            await f.write(expanded_content)
     else:
         if not overwrite:
             # Check for timestamp with optional letters at the end of the stem
@@ -71,8 +72,8 @@ async def aexec_doc(
                 new_filename = f"{doc.stem}_{now}.md"
                 doc_to_exec = doc.with_name(new_filename)
 
-        with open(doc_to_exec, "w") as f:
-            f.write(expanded_content)
+        async with aiofiles.open(doc_to_exec, "w") as f:
+            await f.write(expanded_content)
 
     session = AutoGenSession(doc_to_exec)
     await session.setup()

--- a/packages/domarkx/src/domarkx/action/extract_code_to_file.py
+++ b/packages/domarkx/src/domarkx/action/extract_code_to_file.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pathlib
 import re
@@ -32,7 +33,7 @@ def do_extract_code_to_file(
 ) -> None:
     block_lines = block_inner_content.strip().split("\n")
     if not block_lines:
-        print("⚠️ Block  is empty, skipping.")
+        logging.warning("Block  is empty, skipping.")
         return
 
     first_line = block_lines[0].strip()
@@ -74,21 +75,21 @@ def do_extract_code_to_file(
 
         # Ensure there's content to write, especially after stripping the first line
         if not code_to_write.strip() and not first_line_is_code and len(block_lines) == 1:
-            print(f"⚠️ File '{filepath_extracted}' would be empty after stripping comment. Skipping.")
+            logging.warning(f"File '{filepath_extracted}' would be empty after stripping comment. Skipping.")
             return
         if not code_to_write.strip() and first_line_is_code:  # e.g. only a shebang
-            print(f"📝 Writing file '{filepath_extracted}' which might only contain the shebang/comment.")
+            logging.info(f"Writing file '{filepath_extracted}' which might only contain the shebang/comment.")
 
         try:
             with open(full_path, "w", encoding="utf-8") as f:
                 f.write(code_to_write)
-            print(f"✅ Extracted and wrote: {full_path}")
+            logging.info(f"Extracted and wrote: {full_path}")
         except IOError as e:
-            print(f"❌ Error writing file {full_path}: {e}")
+            logging.error(f"Error writing file {full_path}: {e}")
         except Exception as e:
-            print(f"❌ An unexpected error occurred while writing {full_path}: {e}")
+            logging.error(f"An unexpected error occurred while writing {full_path}: {e}")
     else:
-        print(f'❔ : No filename pattern matched for first line: "{first_line[:70]}..."')
+        logging.warning(f'No filename pattern matched for first line: "{first_line[:70]}..."')
 
 
 def extract_code_to_file(

--- a/packages/domarkx/src/domarkx/action/init.py
+++ b/packages/domarkx/src/domarkx/action/init.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import shutil
 import subprocess
@@ -34,10 +35,10 @@ def init_project(
 
     # Add template handling
     if template_path:
-        print(f"Initializing project from template: {template_path}")
+        logging.info(f"Initializing project from template: {template_path}")
         # TODO: Implement custom template copying
     else:
-        print("Initializing project with default template.")
+        logging.info("Initializing project with default template.")
         default_template_path = os.path.join(os.path.dirname(__file__), "..", "templates", "default")
         for item in os.listdir(default_template_path):
             s = os.path.join(default_template_path, item)
@@ -47,7 +48,7 @@ def init_project(
             else:
                 shutil.copy2(s, d)
 
-    print(f"Project initialized at: {project_path}")
+    logging.info(f"Project initialized at: {project_path}")
 
 
 def register(app: typer.Typer, settings: Settings) -> None:

--- a/packages/domarkx/src/domarkx/tools/apply_diff.py
+++ b/packages/domarkx/src/domarkx/tools/apply_diff.py
@@ -46,7 +46,7 @@ def apply_diff_tool(path: str, diff: str) -> str:
         logging.info(f"Successfully read file '{path}'.")
     except IOError as e:
         logging.error(f"IO error occurred while reading file '{path}': {e}")
-        raise IOError(f"Could not read file '{path}': {e}")
+        raise IOError(f"Could not read file '{path}': {e}") from e
 
     current_lines = list(original_lines)  # Create a copy for modification
     operations: list[Operation] = []
@@ -68,8 +68,8 @@ def apply_diff_tool(path: str, diff: str) -> str:
                 raise ValueError("Invalid diff format: SEARCH block missing ':start_line:' after delimiter.")
             try:
                 start_line_num = int(line.split(":")[2].strip())
-            except (IndexError, ValueError):
-                raise ValueError("Invalid diff format: Invalid line number after ':start_line:'.")
+            except (IndexError, ValueError) as e:
+                raise ValueError("Invalid diff format: Invalid line number after ':start_line:'.") from e
 
             current_line_in_diff += 1
 
@@ -212,4 +212,4 @@ def apply_diff_tool(path: str, diff: str) -> str:
         return f"File '{path}' successfully updated with {len(operations)} diff blocks applied."
     except IOError as e:
         logging.error(f"IO error occurred while writing to file '{path}': {e}")
-        raise IOError(f"Could not write to file '{path}': {e}")
+        raise IOError(f"Could not write to file '{path}': {e}") from e

--- a/packages/domarkx/src/domarkx/tools/portable_tools/file_operations/read_file.py
+++ b/packages/domarkx/src/domarkx/tools/portable_tools/file_operations/read_file.py
@@ -75,15 +75,15 @@ def tool_read_file(
         except PermissionError as e:
             error_msg = f"No permission to read file '{file_path}': {e}"
             logging.error(error_msg)
-            raise PermissionError(error_msg)
+            raise PermissionError(error_msg) from e
         except IOError as e:
             error_msg = f"IO error occurred while reading file '{file_path}': {e}"
             logging.error(error_msg)
-            raise IOError(error_msg)
+            raise IOError(error_msg) from e
         except Exception as e:
             error_msg = f"Unexpected error occurred while reading file '{file_path}': {e}"
             logging.error(error_msg)
-            raise Exception(error_msg)
+            raise Exception(error_msg) from e
 
     def _read_multiple_files(file_list: List[str]) -> str:
         results: list[str] = []

--- a/packages/domarkx/src/domarkx/tools/python_code_handler.py
+++ b/packages/domarkx/src/domarkx/tools/python_code_handler.py
@@ -100,7 +100,7 @@ class LibCstEditor:
             return f"Code successfully saved to '{output_path}'."
         except Exception as e:
             logging.error(f"Failed to save code to '{output_path}': {e}")
-            raise ToolError(f"Failed to save code to '{output_path}': {e}", original_exception=e)
+            raise ToolError(f"Failed to save code to '{output_path}': {e}", original_exception=e) from e
 
     def _apply_transformer(self, transformer: cst.CSTTransformer) -> None:
         """Applies a transformer and updates the module."""
@@ -144,7 +144,7 @@ class LibCstEditor:
                 logging.warning("Custom script did not result in a valid cst.Module update in 'tree' variable.")
         except Exception as e:
             logging.error(f"Error executing custom libcst script: {e}")
-            raise ToolError(f"Error executing custom libcst script: {e}", original_exception=e)
+            raise ToolError(f"Error executing custom libcst script: {e}", original_exception=e) from e
 
     def _get_node_matcher(self, internal_symbol_path: str, target_type: str) -> m.BaseMatcherNode:
         """
@@ -215,7 +215,7 @@ class LibCstEditor:
                     raise ToolError(
                         f"Invalid code content for {self.target_type}: {e}",
                         original_exception=e,
-                    )
+                    ) from e
 
             def leave_Module(self, original_node: cst.Module, updated_node: cst.Module) -> cst.Module:
                 if m.matches(original_node, self.parent_matcher):
@@ -350,14 +350,14 @@ class LibCstEditor:
                             raise ToolError(
                                 f"Invalid new code content for {self.target_type}: {e}",
                                 original_exception=e,
-                            )
+                            ) from e
                         except Exception as e:
                             logging.error(f"Error updating node for {self.target_type}: {e}")
                             # Change generic Exception to ToolError
                             raise ToolError(
                                 f"Error updating node for {self.target_type}: {e}",
                                 original_exception=e,
-                            )
+                            ) from e
                 return updated_node
 
         self._apply_transformer(UpdaterTransformer(target_matcher, new_code_content, target_type))
@@ -478,16 +478,16 @@ def _handle_list_mode_by_symbol(full_symbol: str, target_type: str | None, list_
         raise ToolError(
             f"Could not import symbol '{full_symbol}'. Ensure the module is installed and accessible: {e}",
             original_exception=e,
-        )
+        ) from e
     except AttributeError as e:
         # Changed from AttributeError to ToolError
-        raise ToolError(f"Object not found in symbol '{full_symbol}': {e}", original_exception=e)
+        raise ToolError(f"Object not found in symbol '{full_symbol}': {e}", original_exception=e) from e
     except Exception as e:
         # Changed from generic Exception to ToolError
         raise ToolError(
             f"An error occurred while querying symbol '{full_symbol}': {e}",
             original_exception=e,
-        )
+        ) from e
 
 
 def _handle_list_mode_by_path(
@@ -761,10 +761,10 @@ def _handle_diff_method_mode(target: str) -> str:
         try:
             module_and_class, method_name = target.rsplit(".", 1)
             module_name, class_name = module_and_class.rsplit(".", 1)
-        except ValueError:
+        except ValueError as e:
             raise ToolError(
                 f"Invalid target format for diff_method: '{target}'. Expected 'package.module.ClassName.method_name'."
-            )
+            ) from e
 
         # 2. Import the class
         module = importlib.import_module(module_name)
@@ -822,7 +822,7 @@ def _handle_diff_method_mode(target: str) -> str:
         return "".join(diff)
 
     except (ImportError, AttributeError, ValueError) as e:
-        raise ToolError(f"Error processing symbol '{target}': {e}", original_exception=e)
+        raise ToolError(f"Error processing symbol '{target}': {e}", original_exception=e) from e
 
 
 # Main tool function

--- a/packages/domarkx/src/domarkx/tools/tool_factory.py
+++ b/packages/domarkx/src/domarkx/tools/tool_factory.py
@@ -84,7 +84,7 @@ An error occurred in tool '{func.__name__}':
 {captured_logs_str}
 """.strip()
                 logging.error(f"Tool '{func.__name__}' encountered an error.")
-                raise ToolError(full_error_message, original_exception=e, captured_logs_str=captured_logs_str)
+                raise ToolError(full_error_message, original_exception=e, captured_logs_str=captured_logs_str) from e
             finally:
                 logging.getLogger().removeHandler(rich_handler)
                 logging.getLogger().propagate = True
@@ -173,7 +173,7 @@ class ToolFactory:
             @property
             def source_code(self) -> str:
                 if hasattr(self.fn, "__source_code__"):
-                    return str(getattr(self.fn, "__source_code__"))
+                    return str(self.fn.__source_code__)  # pyright: ignore[reportFunctionMemberAccess]
                 try:
                     return inspect.getsource(self.fn)
                 except TypeError:

--- a/packages/domarkx/src/domarkx/utils/chat_doc_parser.py
+++ b/packages/domarkx/src/domarkx/utils/chat_doc_parser.py
@@ -98,7 +98,7 @@ class MarkdownLLMParser:
                     self.document.global_metadata = yaml.safe_load("".join(yaml_lines))
                     i += 1
                 except yaml.YAMLError as e:
-                    raise ValueError(f"Error parsing YAML front matter: {e}")
+                    raise ValueError(f"Error parsing YAML front matter: {e}") from e
 
         # Parse document-level blocks
         i = self._parse_blocks(lines, i, self.document)

--- a/packages/domarkx/tests/diff_test_module.py
+++ b/packages/domarkx/tests/diff_test_module.py
@@ -15,7 +15,6 @@ class SubClass(BaseClass):
 
     def greeting(self) -> str:
         """Returns a more enthusiastic greeting."""
-        print("This is a new line")
         return "Hello from SubClass!"
 
 

--- a/packages/domarkx/tests/test_python_code_handler.py
+++ b/packages/domarkx/tests/test_python_code_handler.py
@@ -560,7 +560,6 @@ def test_diff_method_mode_overridden_method(tmp_path: pathlib.Path) -> None:
         assert "--- a/BaseClass.greeting" in result
         assert "+++ b/SubClass.greeting" in result
         assert '-    return "Hello from BaseClass"' in result
-        assert '+    print("This is a new line")' in result
         assert '+    return "Hello from SubClass!"' in result
     finally:
         sys.path = old_sys_path

--- a/packages/sire/src/sire/core/commit_object.py
+++ b/packages/sire/src/sire/core/commit_object.py
@@ -179,7 +179,7 @@ class BaseCommitObjectRef(Generic[T]):
             ]
             _logger.debug(f"applied_commit_stack_states : {applied_commit_stack_states}")
             common_path_len = 0
-            for applied_state, need_apply_state in zip(applied_commit_stack_states, commit_stack_states):
+            for applied_state, need_apply_state in zip(applied_commit_stack_states, commit_stack_states, strict=False):
                 if applied_state != need_apply_state:
                     break
                 else:
@@ -356,17 +356,17 @@ if __name__ in ("__main__", "<run_path>"):
 
     base.base_object_ref.do_squash()
     with s3:
-        print(s3.base_object_ref.applied_commit_ref_stack)
+        _logger.info(s3.base_object_ref.applied_commit_ref_stack)
     base.base_object_ref.stop_squash()
 
     base.base_object_ref.do_squash()
     with s2:
-        print(s2.base_object_ref.applied_commit_ref_stack)
+        _logger.info(s2.base_object_ref.applied_commit_ref_stack)
     base.base_object_ref.stop_squash()
 
     s11 = s1.clone_and_add_callable_commit(a)
 
     base.base_object_ref.do_squash()
     with s11:
-        print(s11.base_object_ref.applied_commit_ref_stack)
+        _logger.info(s11.base_object_ref.applied_commit_ref_stack)
     base.base_object_ref.stop_squash()

--- a/packages/sire/src/sire/core/resource_management.py
+++ b/packages/sire/src/sire/core/resource_management.py
@@ -123,6 +123,6 @@ GLOBAL_RESOURCE_RESOLVER.registe_scheme_resolver("file", FileSchemeResourceResol
 if __name__ == "__main__":
     GLOBAL_RESOURCE_RESOLVER.registe_identical_resource_urls(["sha256://jdie", "http://1"])
     GLOBAL_RESOURCE_RESOLVER.registe_identical_resource_urls(["http://2", "http://1"])
-    print(GLOBAL_RESOURCE_RESOLVER.identical_resource_url_map)
+    _logger.info(GLOBAL_RESOURCE_RESOLVER.identical_resource_url_map)
     with GLOBAL_RESOURCE_RESOLVER.get_resource("file:////module/core/precision.py").get_bytes_io() as f:
-        print(f.read(15))
+        _logger.info(f.read(15))

--- a/packages/sire/src/sire/core/runtime_resource_pool.py
+++ b/packages/sire/src/sire/core/runtime_resource_pool.py
@@ -1,6 +1,6 @@
 import logging
 import weakref
-from typing import Any
+from typing import Any, Optional
 
 from ..utils.runtime_resource_util import get_free_mem_size_cpu, get_free_mem_size_cuda_pytorch
 from .runtime_resource_user import ResourcePoolUserABC, resources_device
@@ -9,7 +9,9 @@ _logger = logging.getLogger(__name__)
 
 
 class ResourcePool:
-    def __init__(self, runtime_device: resources_device = resources_device("cpu", 0)) -> None:
+    def __init__(self, runtime_device: Optional[resources_device] = None) -> None:
+        if runtime_device is None:
+            runtime_device = resources_device("cpu", 0)
         self.users: weakref.WeakSet[ResourcePoolUserABC[Any]] = weakref.WeakSet()
         self.resource_device: resources_device = runtime_device
         self.pool_size = 0

--- a/packages/sire/src/sire/core/tensor_typing.py
+++ b/packages/sire/src/sire/core/tensor_typing.py
@@ -1,9 +1,12 @@
+import logging
 from typing import Annotated, Optional
 
 import torch
 from torch.export import Dim
 
 from .annotated_model import AnnotatedBaseModel, find_annotated_model
+
+_logger = logging.getLogger(__name__)
 
 
 class TensorModel(AnnotatedBaseModel):
@@ -19,4 +22,4 @@ DTYPE = "dtype"
 BATCH_DIM = Dim("batch")
 
 if __name__ in ("__main__", "<run_path>"):
-    print(find_annotated_model(Annotated[Tensor, DIMS : [Dim("C", min=1)]], model_type=TensorModel))
+    _logger.info(find_annotated_model(Annotated[Tensor, DIMS : [Dim("C", min=1)]], model_type=TensorModel))

--- a/packages/sire/src/sire/utils/json_helpers.py
+++ b/packages/sire/src/sire/utils/json_helpers.py
@@ -131,9 +131,9 @@ def _reconstruct_from_data(data: Any, expected_type: Type[T]) -> T:
                     dtype_name = "double"
                 # Add more mappings if necessary
             return getattr(torch, dtype_name)
-        except AttributeError:
+        except AttributeError as e:
             logger.error(f"Could not convert string '{data}' to torch.dtype.")
-            raise TypeError(f"Cannot convert '{data}' to torch.dtype")
+            raise TypeError(f"Cannot convert '{data}' to torch.dtype") from e
 
     origin = typing.get_origin(expected_type)
     if origin:

--- a/uv.lock
+++ b/uv.lock
@@ -952,6 +952,7 @@ name = "dam-app"
 version = "0.1.0"
 source = { editable = "packages/dam_app" }
 dependencies = [
+    { name = "aiofiles" },
     { name = "alembic" },
     { name = "dam" },
     { name = "dam-archive" },
@@ -993,6 +994,7 @@ transcode = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiofiles" },
     { name = "alembic" },
     { name = "dam", editable = "packages/dam" },
     { name = "dam-app", extras = ["audio"], marker = "extra == 'all'", editable = "packages/dam_app" },
@@ -1024,6 +1026,7 @@ name = "dam-archive"
 version = "0.1.0"
 source = { editable = "packages/dam_archive" }
 dependencies = [
+    { name = "aiofiles" },
     { name = "dam" },
     { name = "dam-fs" },
     { name = "psutil" },
@@ -1034,6 +1037,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiofiles", specifier = ">=23.2.1" },
     { name = "dam", editable = "packages/dam" },
     { name = "dam-fs", editable = "packages/dam_fs" },
     { name = "psutil" },
@@ -1041,12 +1045,14 @@ requires-dist = [
     { name = "rarfile" },
     { name = "sqlalchemy" },
 ]
+provides-extras = ["test"]
 
 [[package]]
 name = "dam-fs"
 version = "0.1.0"
 source = { editable = "packages/dam_fs" }
 dependencies = [
+    { name = "aiofiles" },
     { name = "dam" },
     { name = "python-magic" },
     { name = "sqlalchemy" },
@@ -1062,6 +1068,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiofiles" },
     { name = "dam", editable = "packages/dam" },
     { name = "dam-media-audio", marker = "extra == 'dev'", editable = "packages/dam_media_audio" },
     { name = "dam-test-utils", marker = "extra == 'dev'", editable = "packages/dam_test_utils" },
@@ -1113,6 +1120,7 @@ name = "dam-media-image"
 version = "0.1.0"
 source = { editable = "packages/dam_media_image" }
 dependencies = [
+    { name = "aiofiles" },
     { name = "dam" },
     { name = "dam-fs" },
     { name = "imagehash" },
@@ -1128,6 +1136,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiofiles" },
     { name = "dam", editable = "packages/dam" },
     { name = "dam-fs", editable = "packages/dam_fs" },
     { name = "imagehash" },
@@ -1143,6 +1152,7 @@ name = "dam-media-transcode"
 version = "0.1.0"
 source = { editable = "packages/dam_media_transcode" }
 dependencies = [
+    { name = "aiofiles" },
     { name = "dam" },
     { name = "dam-fs" },
     { name = "sqlalchemy" },
@@ -1156,6 +1166,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiofiles" },
     { name = "dam", editable = "packages/dam" },
     { name = "dam-fs", editable = "packages/dam_fs" },
     { name = "pytest", marker = "extra == 'dev'" },
@@ -1174,12 +1185,19 @@ dependencies = [
     { name = "sqlalchemy" },
 ]
 
+[package.optional-dependencies]
+test = [
+    { name = "aiofiles" },
+]
+
 [package.metadata]
 requires-dist = [
+    { name = "aiofiles", marker = "extra == 'test'", specifier = ">=23.2.1" },
     { name = "dam", editable = "packages/dam" },
     { name = "pycdlib" },
     { name = "sqlalchemy" },
 ]
+provides-extras = ["test"]
 
 [[package]]
 name = "dam-semantic"
@@ -1474,9 +1492,13 @@ docker-jupyter-executor = [
 jupyter-executor = [
     { name = "autogen-ext", extra = ["jupyter-executor"] },
 ]
+test = [
+    { name = "aiofiles" },
+]
 
 [package.metadata]
 requires-dist = [
+    { name = "aiofiles", marker = "extra == 'test'", specifier = ">=23.2.1" },
     { name = "autogen-agentchat" },
     { name = "autogen-core" },
     { name = "autogen-ext", extras = ["docker-jupyter-executor"], marker = "extra == 'docker-jupyter-executor'" },
@@ -1495,7 +1517,7 @@ requires-dist = [
     { name = "typer" },
     { name = "typer", marker = "extra == 'all'" },
 ]
-provides-extras = ["all", "jupyter-executor", "docker-jupyter-executor"]
+provides-extras = ["all", "jupyter-executor", "docker-jupyter-executor", "test"]
 
 [[package]]
 name = "execnet"


### PR DESCRIPTION
This commit addresses a wide range of linting and type-checking errors that arose after the introduction of new ruff rules. It also refactors several commands and functions to use a more robust StreamProvider pattern instead of raw BinaryIO objects.

Key changes include:
- Fixed numerous linting violations (B018, B904, B023, T201, B008, B007, ASYNC230, ASYNC251, ASYNC221) across multiple packages.
- Refactored GetOrCreateEntityFromStreamCommand and AddHashesFromStreamCommand to use StreamProvider.
- Updated systems and tests to align with the StreamProvider pattern.
- Removed BinaryIO support from dam_archive.open_archive and updated its tests.
- Added `aiofiles` as a dependency where necessary and configured `deptry` to ignore it in test-only scenarios.