### PR TITLE
fix: Remove unused aiofiles dependency

### DIFF
--- a/packages/dam_archive/pyproject.toml
+++ b/packages/dam_archive/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "psutil",
     "sqlalchemy",
     "dam_fs",
-    "aiofiles>=23.2.1",
 ]
 
 [tool.ruff]

--- a/packages/dam_fs/pyproject.toml
+++ b/packages/dam_fs/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     "dam",
     "python-magic",
     "sqlalchemy",
-    "aiofiles",
 ]
 
 [project.optional-dependencies]

--- a/packages/dam_media_transcode/pyproject.toml
+++ b/packages/dam_media_transcode/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     "dam",
     "dam_fs",
     "sqlalchemy",
-    "aiofiles",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1026,7 +1026,6 @@ name = "dam-archive"
 version = "0.1.0"
 source = { editable = "packages/dam_archive" }
 dependencies = [
-    { name = "aiofiles" },
     { name = "dam" },
     { name = "dam-fs" },
     { name = "psutil" },
@@ -1037,7 +1036,6 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiofiles", specifier = ">=23.2.1" },
     { name = "dam", editable = "packages/dam" },
     { name = "dam-fs", editable = "packages/dam_fs" },
     { name = "psutil" },
@@ -1045,14 +1043,12 @@ requires-dist = [
     { name = "rarfile" },
     { name = "sqlalchemy" },
 ]
-provides-extras = ["test"]
 
 [[package]]
 name = "dam-fs"
 version = "0.1.0"
 source = { editable = "packages/dam_fs" }
 dependencies = [
-    { name = "aiofiles" },
     { name = "dam" },
     { name = "python-magic" },
     { name = "sqlalchemy" },
@@ -1068,7 +1064,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiofiles" },
     { name = "dam", editable = "packages/dam" },
     { name = "dam-media-audio", marker = "extra == 'dev'", editable = "packages/dam_media_audio" },
     { name = "dam-test-utils", marker = "extra == 'dev'", editable = "packages/dam_test_utils" },
@@ -1152,7 +1147,6 @@ name = "dam-media-transcode"
 version = "0.1.0"
 source = { editable = "packages/dam_media_transcode" }
 dependencies = [
-    { name = "aiofiles" },
     { name = "dam" },
     { name = "dam-fs" },
     { name = "sqlalchemy" },
@@ -1166,7 +1160,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiofiles" },
     { name = "dam", editable = "packages/dam" },
     { name = "dam-fs", editable = "packages/dam_fs" },
     { name = "pytest", marker = "extra == 'dev'" },
@@ -1186,18 +1179,18 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-test = [
+dev = [
     { name = "aiofiles" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "aiofiles", marker = "extra == 'test'", specifier = ">=23.2.1" },
+    { name = "aiofiles", marker = "extra == 'dev'", specifier = ">=23.2.1" },
     { name = "dam", editable = "packages/dam" },
     { name = "pycdlib" },
     { name = "sqlalchemy" },
 ]
-provides-extras = ["test"]
+provides-extras = ["dev"]
 
 [[package]]
 name = "dam-semantic"
@@ -1236,12 +1229,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-all = [
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "pytest-mock" },
-]
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1252,14 +1239,13 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "dam", editable = "packages/dam" },
-    { name = "dam-sire", extras = ["dev"], marker = "extra == 'all'", editable = "packages/dam_sire" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "pytest-mock", marker = "extra == 'dev'" },
     { name = "sire", editable = "packages/sire" },
 ]
-provides-extras = ["dev", "all"]
+provides-extras = ["dev"]
 
 [[package]]
 name = "dam-source"
@@ -1466,6 +1452,7 @@ name = "domarkx"
 version = "0.1.0"
 source = { editable = "packages/domarkx" }
 dependencies = [
+    { name = "aiofiles" },
     { name = "autogen-agentchat" },
     { name = "autogen-core" },
     { name = "autogen-ext", extra = ["openai"] },
@@ -1482,30 +1469,22 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-all = [
-    { name = "libcst" },
-    { name = "typer" },
-]
 docker-jupyter-executor = [
     { name = "autogen-ext", extra = ["docker-jupyter-executor"] },
 ]
 jupyter-executor = [
     { name = "autogen-ext", extra = ["jupyter-executor"] },
 ]
-test = [
-    { name = "aiofiles" },
-]
 
 [package.metadata]
 requires-dist = [
-    { name = "aiofiles", marker = "extra == 'test'", specifier = ">=23.2.1" },
+    { name = "aiofiles", specifier = ">=23.2.1" },
     { name = "autogen-agentchat" },
     { name = "autogen-core" },
     { name = "autogen-ext", extras = ["docker-jupyter-executor"], marker = "extra == 'docker-jupyter-executor'" },
     { name = "autogen-ext", extras = ["jupyter-executor"], marker = "extra == 'jupyter-executor'" },
     { name = "autogen-ext", extras = ["openai"] },
     { name = "libcst" },
-    { name = "libcst", marker = "extra == 'all'" },
     { name = "openai" },
     { name = "prompt-toolkit" },
     { name = "pydantic" },
@@ -1515,9 +1494,8 @@ requires-dist = [
     { name = "pyyaml" },
     { name = "rich" },
     { name = "typer" },
-    { name = "typer", marker = "extra == 'all'" },
 ]
-provides-extras = ["all", "jupyter-executor", "docker-jupyter-executor", "test"]
+provides-extras = ["jupyter-executor", "docker-jupyter-executor"]
 
 [[package]]
 name = "execnet"


### PR DESCRIPTION
The `deptry` check, part of the `uv run poe check` sequence, was failing due to an unused `aiofiles` dependency in the `dam_archive`, `dam_fs`, and `dam_media_transcode` packages.

This change removes the unused dependency from the `pyproject.toml` files of these packages, allowing the `check` command to pass.