### PR TITLE
This commit addresses a large number of linting errors reported by ru…

### DIFF
--- a/packages/dam_archive/src/dam_archive/base.py
+++ b/packages/dam_archive/src/dam_archive/base.py
@@ -17,22 +17,20 @@ def to_stream_provider(
         return FileStreamProvider(Path(file_or_path))
     if isinstance(file_or_path, Path):
         return FileStreamProvider(file_or_path)
-    else:
-        # If the stream is seekable, we can read it into memory and use it.
-        if file_or_path.seekable():
-            file_or_path.seek(0)
-            # Read the content into an immutable bytes object.
-            content = file_or_path.read()
+    # If the stream is seekable, we can read it into memory and use it.
+    if file_or_path.seekable():
+        file_or_path.seek(0)
+        # Read the content into an immutable bytes object.
+        content = file_or_path.read()
 
-            def bytes_stream_provider() -> BinaryIO:
-                # Create a new stream from the bytes object each time.
-                return io.BytesIO(content)
+        def bytes_stream_provider() -> BinaryIO:
+            # Create a new stream from the bytes object each time.
+            return io.BytesIO(content)
 
-            return CallableStreamProvider(bytes_stream_provider)
-        else:
-            # If the stream is not seekable, we cannot create a reliable
-            # stream provider from it.
-            raise ValueError("Cannot create a stream provider from a non-seekable stream.")
+        return CallableStreamProvider(bytes_stream_provider)
+    # If the stream is not seekable, we cannot create a reliable
+    # stream provider from it.
+    raise ValueError("Cannot create a stream provider from a non-seekable stream.")
 
 
 @dataclass

--- a/packages/dam_archive/src/dam_archive/commands/__init__.py
+++ b/packages/dam_archive/src/dam_archive/commands/__init__.py
@@ -20,16 +20,16 @@ from .split_archives import (
 )
 
 __all__ = [
+    "BindSplitArchiveCommand",
     "CheckArchiveCommand",
+    "CheckArchivePasswordCommand",
+    "CheckSplitArchiveBindingCommand",
     "ClearArchiveComponentsCommand",
+    "CreateMasterArchiveCommand",
     "IngestArchiveCommand",
     "ReissueArchiveMemberEventsCommand",
-    "TagArchivePartCommand",
-    "CheckArchivePasswordCommand",
     "RemoveArchivePasswordCommand",
     "SetArchivePasswordCommand",
-    "BindSplitArchiveCommand",
-    "CheckSplitArchiveBindingCommand",
-    "CreateMasterArchiveCommand",
+    "TagArchivePartCommand",
     "UnbindSplitArchiveCommand",
 ]

--- a/packages/dam_archive/src/dam_archive/handlers/rar.py
+++ b/packages/dam_archive/src/dam_archive/handlers/rar.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from datetime import datetime
 from types import TracebackType
 from typing import (
@@ -60,19 +61,16 @@ class RarArchiveHandler(ArchiveHandler):
 
             if isinstance(e, rarfile.RarWrongPassword):  # type: ignore
                 raise InvalidPasswordError("Invalid password for rar file.") from e
-            elif isinstance(e, rarfile.BadRarFile):  # type: ignore
+            if isinstance(e, rarfile.BadRarFile):  # type: ignore
                 raise IOError(f"Failed to open rar file: {e}") from e
-            else:
-                raise
+            raise
 
         return handler
 
     async def close(self) -> None:
         if self.rar_file:
-            try:
+            with contextlib.suppress(Exception):
                 self.rar_file.close()
-            except Exception:
-                pass
 
         if self._stream_cm_exit:
             await self._stream_cm_exit(None, None, None)

--- a/packages/dam_archive/src/dam_archive/handlers/sevenzip.py
+++ b/packages/dam_archive/src/dam_archive/handlers/sevenzip.py
@@ -146,13 +146,13 @@ class _SevenZipStreamReader(BinaryIO):
     def writable(self) -> bool:
         return False
 
-    def write(self, s: bytes) -> int:  # type: ignore[override]
+    def write(self, _: bytes) -> int:  # type: ignore[override]
         raise OSError("write is not supported")
 
-    def writelines(self, lines: Iterable[bytes]) -> None:  # type: ignore[override]
+    def writelines(self, _: Iterable[bytes]) -> None:  # type: ignore[override]
         raise OSError("writelines is not supported")
 
-    def truncate(self, size: Optional[int] = None) -> int:
+    def truncate(self, _: Optional[int] = None) -> int:
         raise OSError("truncate is not supported")
 
     def __iter__(self) -> Iterator[bytes]:
@@ -201,7 +201,7 @@ class QueueWriter(Py7zIO):
 
         return len(chunk)
 
-    def read(self, size: Optional[int] = None) -> bytes:
+    def read(self, _: Optional[int] = None) -> bytes:
         return b""
 
     def seek(self, offset: int, whence: int = 0) -> int:
@@ -237,7 +237,7 @@ class StreamingFactory(WriterFactory):
         self.results_queue = results_queue
         self.last_writer: Optional[QueueWriter] = None
 
-    def create(self, filename: str, mode: str = "wb") -> Optional[Py7zIO]:  # type: ignore[override]
+    def create(self, filename: str, _: str = "wb") -> Optional[Py7zIO]:  # type: ignore[override]
         if self.last_writer:
             self.last_writer.close()
             self.last_writer = None
@@ -361,11 +361,10 @@ class SevenZipArchiveHandler(ArchiveHandler):
             current_norm_name, data_queue = item
             if current_norm_name == norm_name:
                 return member_info, _SevenZipStreamReader(data_queue)
-            else:
-                # This is a stream for a different file, which can happen
-                # if py7zr decides to extract dependencies. We need to drain it.
-                temp_file = _SevenZipStreamReader(data_queue)
-                temp_file.close()
+            # This is a stream for a different file, which can happen
+            # if py7zr decides to extract dependencies. We need to drain it.
+            temp_file = _SevenZipStreamReader(data_queue)
+            temp_file.close()
 
     async def close(self) -> None:
         for t in self._threads:

--- a/packages/dam_archive/src/dam_archive/main.py
+++ b/packages/dam_archive/src/dam_archive/main.py
@@ -49,8 +49,8 @@ async def open_archive(
             # a different handler.
             raise
         except ArchiveError as e:
-            logger.warning(f"Handler {handler_class.__name__} failed: {e}")
+            logger.warning("Handler %s failed: %s", handler_class.__name__, e)
         except Exception:
-            logger.exception(f"An unexpected error occurred with handler {handler_class.__name__}")
+            logger.exception("An unexpected error occurred with handler %s", handler_class.__name__)
 
     return None

--- a/packages/dam_archive/src/dam_archive/systems/__init__.py
+++ b/packages/dam_archive/src/dam_archive/systems/__init__.py
@@ -21,17 +21,17 @@ from .split_archives import (
 )
 
 __all__ = [
-    "discover_archive_path_siblings_handler",
+    "bind_split_archive_handler",
     "check_archive_handler",
+    "check_archive_password_handler",
+    "check_split_archive_binding_handler",
     "clear_archive_components_handler",
+    "create_master_archive_handler",
+    "discover_archive_path_siblings_handler",
     "get_archive_asset_filenames_handler",
     "get_archive_asset_stream_handler",
     "ingest_archive_members_handler",
-    "check_archive_password_handler",
     "remove_archive_password_handler",
     "set_archive_password_handler",
-    "bind_split_archive_handler",
-    "check_split_archive_binding_handler",
-    "create_master_archive_handler",
     "unbind_split_archive_handler",
 ]

--- a/packages/dam_archive/src/dam_archive/systems/discovery.py
+++ b/packages/dam_archive/src/dam_archive/systems/discovery.py
@@ -1,5 +1,5 @@
 import logging
-import os
+from pathlib import Path
 from typing import List, Optional
 
 from dam.commands.discovery_commands import DiscoverPathSiblingsCommand, PathSibling
@@ -20,17 +20,17 @@ async def discover_archive_path_siblings_handler(
     """
     Handles discovering path-based sibling entities for an entity that is a member of an archive.
     """
-    logger.debug(f"discover_archive_path_siblings_handler running for entity {cmd.entity_id}")
+    logger.debug("discover_archive_path_siblings_handler running for entity %s", cmd.entity_id)
 
     # 1. Get the ArchiveMemberComponent for the starting entity
     member_comp = await transaction.get_component(cmd.entity_id, ArchiveMemberComponent)
     if not member_comp or not member_comp.path_in_archive:
-        logger.debug(f"Entity {cmd.entity_id} is not an archive member. Skipping archive discovery.")
+        logger.debug("Entity %s is not an archive member. Skipping archive discovery.", cmd.entity_id)
         return None
 
     # 2. Determine the parent archive and the directory within it
     parent_archive_id = member_comp.archive_entity_id
-    internal_dir = os.path.dirname(member_comp.path_in_archive)
+    internal_dir = Path(member_comp.path_in_archive).parent
 
     # 3. Find all members of the same parent archive first.
     stmt = select(ArchiveMemberComponent).where(ArchiveMemberComponent.archive_entity_id == parent_archive_id)
@@ -41,12 +41,16 @@ async def discover_archive_path_siblings_handler(
     siblings = [
         PathSibling(entity_id=m.entity_id, path=m.path_in_archive)
         for m in all_members
-        if m.path_in_archive and os.path.dirname(m.path_in_archive) == internal_dir
+        if m.path_in_archive and Path(m.path_in_archive).parent == internal_dir
     ]
 
     if siblings:
         logger.info(
-            f"Found {len(siblings)} archive siblings for entity {cmd.entity_id} in archive {parent_archive_id}:{internal_dir}."
+            "Found %s archive siblings for entity %s in archive %s:%s.",
+            len(siblings),
+            cmd.entity_id,
+            parent_archive_id,
+            internal_dir,
         )
         return siblings
 

--- a/packages/dam_archive/src/dam_archive/systems/ingestion.py
+++ b/packages/dam_archive/src/dam_archive/systems/ingestion.py
@@ -1,3 +1,4 @@
+import contextlib
 import io
 import logging
 from contextlib import asynccontextmanager
@@ -10,6 +11,7 @@ from typing import (
     BinaryIO,
     List,
     Optional,
+    TypedDict,
     Union,
     cast,
 )
@@ -37,6 +39,7 @@ from dam.system_events.requests import InformationRequest, PasswordRequest
 from dam.utils.stream_utils import ChainedStream
 from sqlalchemy import select
 
+from ..base import ArchiveMemberInfo
 from ..commands.ingestion import (
     CheckArchiveCommand,
     ClearArchiveComponentsCommand,
@@ -120,10 +123,8 @@ def _create_archive_member_stream_provider(
             finally:
                 # Ensure the member stream is closed if it's not done by the consumer
                 if member_stream:
-                    try:
+                    with contextlib.suppress(Exception):
                         member_stream.close()
-                    except Exception:
-                        pass
                 await archive.close()
 
     return ArchiveMemberStreamProvider()
@@ -159,17 +160,17 @@ async def get_archive_asset_stream_handler(
         all_providers = await world.dispatch_command(archive_stream_cmd).get_all_results()
         valid_providers = [p for p in all_providers if p is not None]
         if not valid_providers:
-            logger.warning(f"Could not get stream provider for parent archive {target_entity_id}")
+            logger.warning("Could not get stream provider for parent archive %s", target_entity_id)
             continue
         archive_stream_provider = valid_providers[0]
 
         if not archive_stream_provider:
-            logger.warning(f"Could not get stream provider for parent archive {target_entity_id}")
+            logger.warning("Could not get stream provider for parent archive %s", target_entity_id)
             continue
 
         mime_type = await get_content_mime_type(transaction.session, target_entity_id)
         if not mime_type:
-            logger.warning(f"Could not get mime type for parent archive {target_entity_id}")
+            logger.warning("Could not get mime type for parent archive %s", target_entity_id)
             continue
 
         return _create_archive_member_stream_provider(
@@ -197,23 +198,111 @@ async def get_archive_asset_filenames_handler(
     return None
 
 
-async def _process_archive(
+class ChainedStreamProvider(StreamProvider):
+    def __init__(self, providers: List[StreamProvider]):
+        self._providers = providers
+
+    @asynccontextmanager
+    async def get_stream(self) -> AsyncIterator[BinaryIO]:
+        streams: List[BinaryIO] = []
+        context_managers: List[AsyncContextManager[BinaryIO]] = []
+        try:
+            for p in self._providers:
+                cm = p.get_stream()
+                streams.append(await cm.__aenter__())
+                context_managers.append(cm)
+
+            chained_stream = cast(BinaryIO, ChainedStream(streams))
+            yield chained_stream
+        finally:
+            for cm in reversed(context_managers):
+                await cm.__aexit__(None, None, None)
+
+
+async def _get_archive_stream_provider(  # noqa: PLR0911
+    cmd: IngestArchiveCommand,
+    transaction: WorldTransaction,
+    world: Annotated[World, "Resource"],
+) -> tuple[Optional[StreamProvider], Optional[ProgressError]]:
+    """Determines the correct StreamProvider for the given IngestArchiveCommand."""
+    if cmd.stream_provider:
+        logger.info("Processing archive for entity %s from provided stream provider.", cmd.entity_id)
+        return cmd.stream_provider, None
+
+    manifest_comp = await transaction.get_component(cmd.entity_id, SplitArchiveManifestComponent)
+    part_info = await transaction.get_component(cmd.entity_id, SplitArchivePartInfoComponent)
+
+    # Case 1: Master entity for a split archive.
+    if manifest_comp:
+        logger.info("Entity %s is a split archive master. Chaining part streams.", cmd.entity_id)
+        stmt = (
+            select(SplitArchivePartInfoComponent)
+            .where(SplitArchivePartInfoComponent.master_entity_id == cmd.entity_id)
+            .order_by(SplitArchivePartInfoComponent.part_num)
+        )
+        result = await transaction.session.execute(stmt)
+        parts = result.scalars().all()
+        part_entity_ids = [part.entity_id for part in parts]
+        try:
+            part_stream_providers: List[StreamProvider] = []
+            for part_entity_id in part_entity_ids:
+                stream_cmd = GetAssetStreamCommand(entity_id=part_entity_id)
+                all_providers = await world.dispatch_command(stream_cmd).get_all_results()
+                valid_providers = [p for p in all_providers if p is not None]
+                if valid_providers:
+                    part_stream_providers.append(valid_providers[0])
+                else:
+                    raise ValueError(f"Stream provider for part {part_entity_id} is None")
+
+            return ChainedStreamProvider(part_stream_providers), None
+        except (ValueError, FileNotFoundError) as e:
+            logger.error("Could not get stream for split archive part: %s", e)
+            return None, ProgressError(message=str(e), exception=e)
+
+    # Case 2: Part of an already assembled split archive.
+    if not manifest_comp and part_info and part_info.master_entity_id:
+        logger.info(
+            "Entity %s is part of an assembled split archive (master: %s). "
+            "Ingestion should be initiated from the master entity. Skipping ingestion for this part.",
+            cmd.entity_id,
+            part_info.master_entity_id,
+        )
+        return None, None
+
+    # Case 3: Part of a non-assembled split archive.
+    if not manifest_comp and part_info and not part_info.master_entity_id:
+        err_msg = (
+            f"Entity {cmd.entity_id} is part of a non-assembled split archive. "
+            "Please run 'discover-and-bind' or 'create-master' command first."
+        )
+        return None, ProgressError(message=err_msg, exception=RuntimeError(err_msg))
+
+    # Case 4: Regular, single-file archive.
+    if not manifest_comp and not part_info:
+        logger.info("Entity %s is a single-file archive. Getting stream provider.", cmd.entity_id)
+        try:
+            stream_provider = await cmd.get_stream_provider(world)
+            return stream_provider, None
+        except (ValueError, FileNotFoundError) as e:
+            logger.error("Could not get stream for single-file archive %s: %s", cmd.entity_id, e)
+            return None, ProgressError(message=str(e), exception=e)
+
+    return None, None  # Should not be reached, but mypy needs it.
+
+
+async def _resolve_password_and_open_archive(
     cmd: IngestArchiveCommand,
     archive_stream_provider: StreamProvider,
-    world: Annotated[World, "Resource"],
     transaction: WorldTransaction,
-) -> AsyncGenerator[Union[SystemProgressEvent, NewEntityCreatedEvent, InformationRequest[Any]], Any]:
+    mime_type: str,
+) -> AsyncGenerator[Union[SystemProgressEvent, InformationRequest[Any]], Any]:
     """
-    The core extraction and event-issuing logic for an archive.
-    It performs the initial ingestion and handles encrypted archives by yielding PasswordRequests.
+    Handles password resolution and opens the archive.
+    This is an async generator that yields ProgressError or PasswordRequest events.
+    If successful, it yields a tuple of (ArchiveHandler, correct_password) as its
+    final event before stopping.
     """
-    yield ProgressStarted()
     entity_id = cmd.entity_id
-
-    mime_type = await get_content_mime_type(transaction.session, entity_id)
-    if not mime_type:
-        yield ProgressError(message=f"Could not get mime type for archive entity {entity_id}", exception=ValueError())
-        return
 
     async def _try_open_archive(password: Optional[str]):
         try:
@@ -226,13 +315,8 @@ async def _process_archive(
             raise
 
     # --- Password Resolution ---
-    archive = None
-    correct_password = None
     stored_password_comp = await transaction.get_component(entity_id, ArchivePasswordComponent)
-
-    # 1. Try passwords in a specific, non-interactive order.
     passwords_to_try = [cmd.password, stored_password_comp.password if stored_password_comp else None, None]
-    # Create a list of unique passwords to try, preserving order. `None` is a valid entry.
     unique_passwords = list(dict.fromkeys(passwords_to_try))
 
     for pwd in unique_passwords:
@@ -241,35 +325,131 @@ async def _process_archive(
             yield opened_archive
             return
         if opened_archive:
-            archive, correct_password = opened_archive, pwd
-            logger.info(f"Successfully opened archive {entity_id} with password: {'yes' if pwd else 'no'}")
-            break
+            logger.info("Successfully opened archive %s with password: %s", entity_id, "yes" if pwd else "no")
+            yield (opened_archive, pwd)
+            return
 
-    # 2. If still not open, enter the interactive loop.
-    if not archive:
-        is_first_request = True
+    # Interactive loop if passwords failed
+    is_first_request = True
+    while True:
+        message = "Invalid password." if not is_first_request else f"Password required for archive {entity_id}."
+        new_password = yield PasswordRequest(message=message)
+        is_first_request = False
+
+        if new_password is None:
+            yield ProgressError(
+                message=f"Password not provided for archive entity {entity_id}",
+                exception=PasswordRequiredError(),
+            )
+            return
+
+        opened_archive = await _try_open_archive(new_password)
+        if isinstance(opened_archive, ProgressError):
+            yield opened_archive
+            return
+        if opened_archive:
+            logger.info("Successfully opened archive %s with provided password.", entity_id)
+            yield (opened_archive, new_password)
+            return
+        else:
+            logger.info("Invalid password provided for archive %s.", entity_id)
+
+
+class MemberProcessingContext(TypedDict):
+    entity_id: int
+    member_mod_times: dict
+    world: Annotated[World, "Resource"]
+    transaction: WorldTransaction
+
+
+async def _process_member(
+    member_info: ArchiveMemberInfo,
+    member_file: BinaryIO,
+    context: MemberProcessingContext,
+) -> AsyncGenerator[NewEntityCreatedEvent, None]:
+    """Processes a single member of an archive, yielding a NewEntityCreatedEvent on success."""
+    world = context["world"]
+    transaction = context["transaction"]
+    entity_id = context["entity_id"]
+    member_mod_times = context["member_mod_times"]
+
+    with member_file as member_stream:
+        # --- Memory-constrained stream handling ---
+        available_memory = psutil.virtual_memory().available
+        memory_limit = int(available_memory * 0.5)
+        in_memory_buffer = io.BytesIO(member_stream.read(memory_limit))
+        is_eof = not member_stream.read(1)
+
+        event_stream_provider: Optional[StreamProvider] = None
+        if is_eof:
+            in_memory_buffer.seek(0)
+            buffer_content = in_memory_buffer.read()
+
+            def event_provider(content: bytes = buffer_content) -> BinaryIO:
+                return io.BytesIO(content)
+
+            event_stream_provider = CallableStreamProvider(event_provider)
+            command_stream_provider = event_stream_provider
+        else:
+            in_memory_buffer.seek(0)
+            stream_for_command = cast(BinaryIO, ChainedStream([in_memory_buffer, member_stream]))
+            command_stream_provider = _create_command_stream_provider(stream_for_command)
+
+        # --- Entity handling ---
+        get_or_create_cmd = GetOrCreateEntityFromStreamCommand(stream_provider=command_stream_provider)
+        member_entity_tuple = await world.dispatch_command(get_or_create_cmd).get_one_value()
+        if not member_entity_tuple:
+            raise ValueError(f"Could not get or create entity for archive member '{member_info.name}'")
+
+        member_entity, _ = member_entity_tuple
+        member_entity_id = member_entity.id
+
+        # Add ArchiveMemberComponent
+        member_comp = ArchiveMemberComponent(
+            archive_entity_id=entity_id,
+            path_in_archive=member_info.name,
+            modified_at=member_mod_times.get(member_info.name),
+        )
+        await transaction.add_component_to_entity(member_entity_id, member_comp)
+
+        # --- Event Emission ---
+        yield NewEntityCreatedEvent(
+            entity_id=member_entity_id,
+            stream_provider=event_stream_provider,
+            filename=member_info.name,
+        )
+
+
+async def _process_archive(
+    cmd: IngestArchiveCommand,
+    archive_stream_provider: StreamProvider,
+    world: Annotated[World, "Resource"],
+    transaction: WorldTransaction,
+) -> AsyncGenerator[Union[SystemProgressEvent, NewEntityCreatedEvent, InformationRequest[Any]], Any]:
+    """
+    The core extraction and event-issuing logic for an archive.
+    """
+    yield ProgressStarted()
+    entity_id = cmd.entity_id
+
+    mime_type = await get_content_mime_type(transaction.session, entity_id)
+    if not mime_type:
+        yield ProgressError(message=f"Could not get mime type for archive entity {entity_id}", exception=ValueError())
+        return
+
+    # --- Password Resolution ---
+    archive, correct_password = None, None
+    password_gen = _resolve_password_and_open_archive(cmd, archive_stream_provider, transaction, mime_type)
+    response = None
+    try:
         while True:
-            message = "Invalid password." if not is_first_request else f"Password required for archive {entity_id}."
-            new_password = yield PasswordRequest(message=message)
-            is_first_request = False
-
-            if new_password is None:
-                yield ProgressError(
-                    message=f"Password not provided for archive entity {entity_id}",
-                    exception=PasswordRequiredError(),
-                )
-                return
-
-            opened_archive = await _try_open_archive(new_password)
-            if isinstance(opened_archive, ProgressError):
-                yield opened_archive
-                return
-            if opened_archive:
-                archive, correct_password = opened_archive, new_password
-                logger.info(f"Successfully opened archive {entity_id} with provided password.")
+            event = await password_gen.asend(response)
+            if isinstance(event, tuple):
+                archive, correct_password = event
                 break
-            else:
-                logger.info(f"Invalid password provided for archive {entity_id}.")
+            response = yield event
+    except StopAsyncIteration:
+        pass
 
     if not archive:
         return
@@ -277,84 +457,32 @@ async def _process_archive(
     try:
         # --- Main Logic ---
         all_members = archive.list_files()
-        logger.info(f"Entity {entity_id} is being ingested for the first time.")
+        logger.info("Entity %s is being ingested for the first time.", entity_id)
         total_size = sum(m.size for m in all_members)
         yield ProgressUpdate(total=total_size, current=0, message="Starting ingestion.")
 
         processed_size = 0
-        member_mod_times = {m.name: m.modified_at for m in all_members}
+        context: MemberProcessingContext = {
+            "entity_id": entity_id,
+            "member_mod_times": {m.name: m.modified_at for m in all_members},
+            "world": world,
+            "transaction": transaction,
+        }
 
         for member_info, member_file in archive.iter_files():
             try:
-                with member_file as member_stream:
-                    # --- Memory-constrained stream handling ---
-                    available_memory = psutil.virtual_memory().available
-                    memory_limit = int(available_memory * 0.5)
-                    in_memory_buffer = io.BytesIO(member_stream.read(memory_limit))
-                    is_eof = not member_stream.read(1)
-
-                    event_stream_provider: Optional[StreamProvider] = None
-                    stream_for_command: BinaryIO
-
-                    if is_eof:
-                        # Read the entire content into an immutable bytes object once.
-                        in_memory_buffer.seek(0)
-                        buffer_content = in_memory_buffer.read()
-
-                        # Create a provider that generates new streams from the bytes object for the event.
-                        def event_provider(content: bytes = buffer_content) -> BinaryIO:
-                            return io.BytesIO(content)
-
-                        event_stream_provider = CallableStreamProvider(event_provider)
-                        command_stream_provider = event_stream_provider
-                    else:
-                        # For large files, we can't provide a re-readable event stream.
-                        # The command gets a chained stream which consumes the buffer and the rest of the file stream.
-                        in_memory_buffer.seek(0)
-                        stream_for_command = cast(BinaryIO, ChainedStream([in_memory_buffer, member_stream]))
-                        command_stream_provider = _create_command_stream_provider(stream_for_command)
-
-                    # --- Entity handling (Create vs. Re-issue) ---
-                    # Initial ingestion: Get or create entity from stream
-                    member_entity_id: Optional[int] = None
-                    get_or_create_cmd = GetOrCreateEntityFromStreamCommand(stream_provider=command_stream_provider)
-                    member_entity_tuple = await world.dispatch_command(get_or_create_cmd).get_one_value()
-                    if member_entity_tuple:
-                        member_entity, _ = member_entity_tuple
-                        member_entity_id = member_entity.id
-
-                    if not member_entity_id:
-                        raise ValueError(f"Could not get or create entity for archive member '{member_info.name}'")
-
-                    # Add ArchiveMemberComponent for new members first to avoid race conditions.
-                    member_comp = ArchiveMemberComponent(
-                        archive_entity_id=entity_id,
-                        path_in_archive=member_info.name,
-                        modified_at=member_mod_times.get(member_info.name),
-                    )
-                    await transaction.add_component_to_entity(member_entity_id, member_comp)
-
-                    # --- Event Emission ---
-                    if member_entity_id:
-                        yield NewEntityCreatedEvent(
-                            entity_id=member_entity_id,
-                            stream_provider=event_stream_provider,
-                            filename=member_info.name,
-                        )
-
-                # --- Progress Update ---
+                async for event in _process_member(member_info, member_file, context):
+                    yield event
+            except Exception as e:
+                logger.error("Failed to process member '%s' from archive %s: %s", member_info.name, entity_id, e)
+            finally:
                 processed_size += member_info.size
                 yield ProgressUpdate(
                     total=total_size, current=processed_size, message=f"Processed '{member_info.name}'."
                 )
 
-            except Exception as e:
-                logger.error(f"Failed to process member '{member_info.name}' from archive {entity_id}: {e}")
-                # Don't abort the whole process for one bad file
-                continue
-
         # --- Finalization ---
-        # Save the correct password if it wasn't already stored
+        stored_password_comp = await transaction.get_component(entity_id, ArchivePasswordComponent)
         if correct_password and (not stored_password_comp or correct_password != stored_password_comp.password):
             await world.dispatch_command(
                 SetArchivePasswordCommand(entity_id=entity_id, password=correct_password)
@@ -362,7 +490,7 @@ async def _process_archive(
 
         info_comp = ArchiveInfoComponent(comment=archive.comment)
         await transaction.add_or_update_component(entity_id, info_comp)
-        logger.info(f"Finished processing archive {entity_id}, processed {len(all_members)} members.")
+        logger.info("Finished processing archive %s, processed %s members.", entity_id, len(all_members))
         yield ProgressCompleted()
 
     finally:
@@ -380,98 +508,16 @@ async def ingest_archive_members_handler(
     Handles processing an archive. It's the main entry point for ingestion.
     This handler determines the stream provider and then calls the main processing logic.
     """
-    logger.info(f"Ingestion command received for entity {cmd.entity_id}")
+    logger.info("Ingestion command received for entity %s", cmd.entity_id)
 
-    # --- Determine Stream Provider ---
-    archive_stream_provider: Optional[StreamProvider] = None
+    archive_stream_provider, error = await _get_archive_stream_provider(cmd, transaction, world)
 
-    if cmd.stream_provider:
-        logger.info(f"Processing archive for entity {cmd.entity_id} from provided stream provider.")
-        archive_stream_provider = cmd.stream_provider
-    else:
-        # Case 1: Master entity for a split archive.
-        manifest_comp = await transaction.get_component(cmd.entity_id, SplitArchiveManifestComponent)
-        if manifest_comp:
-            logger.info(f"Entity {cmd.entity_id} is a split archive master. Chaining part streams.")
+    if error:
+        yield error
+        return
 
-            class ChainedStreamProvider(StreamProvider):
-                def __init__(self, providers: List[StreamProvider]):
-                    self._providers = providers
-
-                @asynccontextmanager
-                async def get_stream(self) -> AsyncIterator[BinaryIO]:
-                    streams: List[BinaryIO] = []
-                    context_managers: List[AsyncContextManager[BinaryIO]] = []
-                    try:
-                        for p in self._providers:
-                            cm = p.get_stream()
-                            streams.append(await cm.__aenter__())
-                            context_managers.append(cm)
-
-                        chained_stream = cast(BinaryIO, ChainedStream(streams))
-                        yield chained_stream
-                    finally:
-                        for cm in reversed(context_managers):
-                            await cm.__aexit__(None, None, None)
-
-            stmt = (
-                select(SplitArchivePartInfoComponent)
-                .where(SplitArchivePartInfoComponent.master_entity_id == cmd.entity_id)
-                .order_by(SplitArchivePartInfoComponent.part_num)
-            )
-            result = await transaction.session.execute(stmt)
-            parts = result.scalars().all()
-            part_entity_ids = [part.entity_id for part in parts]
-            try:
-                part_stream_providers: List[StreamProvider] = []
-                for part_entity_id in part_entity_ids:
-                    stream_cmd = GetAssetStreamCommand(entity_id=part_entity_id)
-                    all_providers = await world.dispatch_command(stream_cmd).get_all_results()
-                    valid_providers = [p for p in all_providers if p is not None]
-                    if valid_providers:
-                        part_stream_providers.append(valid_providers[0])
-                    else:
-                        raise ValueError(f"Stream provider for part {part_entity_id} is None")
-
-                archive_stream_provider = ChainedStreamProvider(part_stream_providers)
-            except (ValueError, FileNotFoundError) as e:
-                logger.error(f"Could not get stream for split archive part: {e}")
-                yield ProgressError(message=str(e), exception=e)
-                return
-
-        # Case 2: Part of an already assembled split archive.
-        part_info = await transaction.get_component(cmd.entity_id, SplitArchivePartInfoComponent)
-        if not manifest_comp and part_info and part_info.master_entity_id:
-            logger.info(
-                f"Entity {cmd.entity_id} is part of an assembled split archive (master: {part_info.master_entity_id}). "
-                "Ingestion should be initiated from the master entity. Skipping ingestion for this part."
-            )
-            return
-
-        # Case 3: Part of a non-assembled split archive.
-        if not manifest_comp and part_info and not part_info.master_entity_id:
-            err_msg = (
-                f"Entity {cmd.entity_id} is part of a non-assembled split archive. "
-                "Please run 'discover-and-bind' or 'create-master' command first."
-            )
-            yield ProgressError(message=err_msg, exception=RuntimeError(err_msg))
-            return
-
-        # Case 4: Regular, single-file archive.
-        if not manifest_comp and not part_info:
-            logger.info(f"Entity {cmd.entity_id} is a single-file archive. Getting stream provider.")
-            try:
-                archive_stream_provider = await cmd.get_stream_provider(world)
-            except (ValueError, FileNotFoundError) as e:
-                logger.error(f"Could not get stream for single-file archive {cmd.entity_id}: {e}")
-                yield ProgressError(message=str(e), exception=e)
-                return
-
-    # --- Call Processing Logic ---
     if not archive_stream_provider:
-        yield ProgressError(
-            message=f"Could not determine a stream provider for entity {cmd.entity_id}", exception=ValueError()
-        )
+        # This can happen if the file is a part of an already assembled archive, which is not an error.
         return
 
     # The `_process_archive` generator can now make requests, so we need to
@@ -498,7 +544,7 @@ async def clear_archive_components_handler(
     info_comp = await transaction.get_component(cmd.entity_id, ArchiveInfoComponent)
     if info_comp:
         await transaction.remove_component(info_comp)
-        logger.info(f"Deleted ArchiveInfoComponent from entity {cmd.entity_id}")
+        logger.info("Deleted ArchiveInfoComponent from entity %s", cmd.entity_id)
 
     # Find all ArchiveMemberComponents that point to this archive entity
     stmt = select(ArchiveMemberComponent).where(ArchiveMemberComponent.archive_entity_id == cmd.entity_id)
@@ -508,6 +554,7 @@ async def clear_archive_components_handler(
     for member_comp in member_components:
         await transaction.remove_component(member_comp)
         logger.info(
-            f"Deleted ArchiveMemberComponent from member entity {member_comp.entity_id} "
-            f"(linked to archive {cmd.entity_id})"
+            "Deleted ArchiveMemberComponent from member entity %s (linked to archive %s)",
+            member_comp.entity_id,
+            cmd.entity_id,
         )

--- a/packages/dam_archive/src/dam_archive/systems/password.py
+++ b/packages/dam_archive/src/dam_archive/systems/password.py
@@ -32,7 +32,7 @@ async def remove_archive_password_handler(
     component = await transaction.get_component(cmd.entity_id, ArchivePasswordComponent)
     if component:
         await transaction.remove_component(component)
-        logger.info(f"Removed ArchivePasswordComponent from entity {cmd.entity_id}")
+        logger.info("Removed ArchivePasswordComponent from entity %s", cmd.entity_id)
 
 
 @system(on_command=SetArchivePasswordCommand)

--- a/packages/dam_archive/tests/conftest.py
+++ b/packages/dam_archive/tests/conftest.py
@@ -5,14 +5,13 @@ from pathlib import Path
 import pytest
 from dam.core import World
 from dam_fs.plugin import FsPlugin
-from pytest import TempPathFactory
 
 from dam_archive.plugin import ArchivePlugin
 
 pytest_plugins = ["dam_test_utils.fixtures"]
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def setup_world_with_plugins(test_world_alpha: World):
     """Automatically sets up the test world with necessary plugins."""
     test_world_alpha.add_plugin(FsPlugin())
@@ -20,7 +19,7 @@ def setup_world_with_plugins(test_world_alpha: World):
 
 
 @pytest.fixture(scope="session")
-def test_7z_content(tmp_path_factory: TempPathFactory) -> Path:
+def test_7z_content(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Creates a directory with content for 7z archives."""
     content_dir = tmp_path_factory.mktemp("test_7z_content")
     (content_dir / "file.txt").write_text("This is a test file for 7z archives.\n")
@@ -32,7 +31,7 @@ def test_7z_content(tmp_path_factory: TempPathFactory) -> Path:
 
 
 @pytest.fixture(scope="session")
-def regular_7z_archive(tmp_path_factory: TempPathFactory, test_7z_content: Path) -> Path:
+def regular_7z_archive(tmp_path_factory: pytest.TempPathFactory, test_7z_content: Path) -> Path:
     """Creates a regular 7z archive."""
     archive_path = tmp_path_factory.mktemp("archives") / "regular_archive.7z"
     subprocess.run(
@@ -44,7 +43,7 @@ def regular_7z_archive(tmp_path_factory: TempPathFactory, test_7z_content: Path)
 
 
 @pytest.fixture(scope="session")
-def protected_7z_archive(tmp_path_factory: TempPathFactory, test_7z_content: Path) -> Path:
+def protected_7z_archive(tmp_path_factory: pytest.TempPathFactory, test_7z_content: Path) -> Path:
     """Creates a password-protected 7z archive."""
     archive_path = tmp_path_factory.mktemp("archives") / "protected_archive.7z"
     subprocess.run(
@@ -56,7 +55,7 @@ def protected_7z_archive(tmp_path_factory: TempPathFactory, test_7z_content: Pat
 
 
 @pytest.fixture(scope="session")
-def bcj2_7z_archive(tmp_path_factory: TempPathFactory, test_7z_content: Path) -> Path:
+def bcj2_7z_archive(tmp_path_factory: pytest.TempPathFactory, test_7z_content: Path) -> Path:
     """Creates a BCJ2-filtered 7z archive."""
     archive_path = tmp_path_factory.mktemp("archives") / "bcj2_archive.7z"
     subprocess.run(

--- a/packages/dam_archive/tests/test_archive.py
+++ b/packages/dam_archive/tests/test_archive.py
@@ -9,13 +9,16 @@ from dam_archive.base import to_stream_provider
 from dam_archive.exceptions import InvalidPasswordError
 from dam_archive.main import open_archive
 
+CONTENT1 = b"content1"
+CONTENT2 = b"content2"
+
 
 @pytest.fixture
 def dummy_zip_file(tmp_path: Path) -> Path:
     zip_path = tmp_path / "test.zip"
     with zipfile.ZipFile(zip_path, "w") as zf:
-        zf.writestr("file1.txt", b"content1")
-        zf.writestr("dir/file2.txt", b"content2")
+        zf.writestr("file1.txt", CONTENT1)
+        zf.writestr("dir/file2.txt", CONTENT2)
         zf.comment = b"test comment"
     return zip_path
 
@@ -35,15 +38,15 @@ async def test_open_zip_archive(dummy_zip_file: Path) -> None:
 
     member_info, f_in_zip = archive.open_file("file1.txt")
     with f_in_zip:
-        assert f_in_zip.read() == b"content1"
+        assert f_in_zip.read() == CONTENT1
     assert member_info.name == "file1.txt"
-    assert member_info.size == 8
+    assert member_info.size == len(CONTENT1)
 
     member_info, f_in_zip = archive.open_file("dir/file2.txt")
     with f_in_zip:
-        assert f_in_zip.read() == b"content2"
+        assert f_in_zip.read() == CONTENT2
     assert member_info.name == "dir/file2.txt"
-    assert member_info.size == 8
+    assert member_info.size == len(CONTENT2)
     await archive.close()
 
 
@@ -101,13 +104,13 @@ async def test_open_zip_archive_with_stream_provider(dummy_zip_file: Path) -> No
 
     member_info, f_in_zip = archive.open_file("file1.txt")
     with f_in_zip:
-        assert f_in_zip.read() == b"content1"
+        assert f_in_zip.read() == CONTENT1
     assert member_info.name == "file1.txt"
-    assert member_info.size == 8
+    assert member_info.size == len(CONTENT1)
 
     member_info, f_in_zip = archive.open_file("dir/file2.txt")
     with f_in_zip:
-        assert f_in_zip.read() == b"content2"
+        assert f_in_zip.read() == CONTENT2
     assert member_info.name == "dir/file2.txt"
-    assert member_info.size == 8
+    assert member_info.size == len(CONTENT2)
     await archive.close()

--- a/packages/dam_archive/tests/test_clear_system.py
+++ b/packages/dam_archive/tests/test_clear_system.py
@@ -1,8 +1,8 @@
 from typing import List
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from dam.core.transaction import WorldTransaction
+from pytest_mock import MockerFixture
 
 from dam_archive.commands import ClearArchiveComponentsCommand
 from dam_archive.models import ArchiveInfoComponent, ArchiveMemberComponent
@@ -10,7 +10,7 @@ from dam_archive.systems import clear_archive_components_handler
 
 
 @pytest.mark.asyncio
-async def test_clear_archive_components_handler():
+async def test_clear_archive_components_handler(mocker: MockerFixture):
     """
     Tests that the clear_archive_components_handler system correctly removes
     the ArchiveInfoComponent and all associated ArchiveMemberComponents.
@@ -30,9 +30,9 @@ async def test_clear_archive_components_handler():
         member_components.append(comp)
 
     # Mock the transaction and its session
-    mock_transaction = AsyncMock(spec=WorldTransaction)
-    mock_session = AsyncMock()
-    mock_result = MagicMock()
+    mock_transaction = mocker.AsyncMock(spec=WorldTransaction)
+    mock_session = mocker.AsyncMock()
+    mock_result = mocker.MagicMock()
     mock_result.scalars.return_value.all.return_value = member_components
     mock_session.execute.return_value = mock_result
     mock_transaction.session = mock_session

--- a/packages/dam_archive/tests/test_filename_handler.py
+++ b/packages/dam_archive/tests/test_filename_handler.py
@@ -1,21 +1,20 @@
-from unittest.mock import AsyncMock
-
 import pytest
 from dam.commands.asset_commands import GetAssetFilenamesCommand
+from pytest_mock import MockerFixture
 
 from dam_archive.models import ArchiveMemberComponent
 from dam_archive.systems import get_archive_asset_filenames_handler
 
 
 @pytest.mark.asyncio
-async def test_get_archive_asset_filenames_handler_with_filename() -> None:
+async def test_get_archive_asset_filenames_handler_with_filename(mocker: MockerFixture) -> None:
     """
     Tests that the handler returns the filename when an ArchiveMemberComponent exists.
     """
     entity_id = 1
     path_in_archive = "path/to/file.jpg"
 
-    mock_transaction = AsyncMock()
+    mock_transaction = mocker.AsyncMock()
     mock_transaction.get_components.return_value = [
         ArchiveMemberComponent(archive_entity_id=99, path_in_archive=path_in_archive, modified_at=None)
     ]
@@ -29,13 +28,13 @@ async def test_get_archive_asset_filenames_handler_with_filename() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_archive_asset_filenames_handler_no_component() -> None:
+async def test_get_archive_asset_filenames_handler_no_component(mocker: MockerFixture) -> None:
     """
     Tests that the handler returns None when no ArchiveMemberComponent exists.
     """
     entity_id = 1
 
-    mock_transaction = AsyncMock()
+    mock_transaction = mocker.AsyncMock()
     mock_transaction.get_components.return_value = []
 
     command = GetAssetFilenamesCommand(entity_id=entity_id)
@@ -47,13 +46,13 @@ async def test_get_archive_asset_filenames_handler_no_component() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_archive_asset_filenames_handler_no_filename() -> None:
+async def test_get_archive_asset_filenames_handler_no_filename(mocker: MockerFixture) -> None:
     """
     Tests that the handler returns an empty string when the component exists but has no path.
     """
     entity_id = 1
 
-    mock_transaction = AsyncMock()
+    mock_transaction = mocker.AsyncMock()
     mock_transaction.get_components.return_value = [
         ArchiveMemberComponent(archive_entity_id=99, path_in_archive="", modified_at=None)
     ]

--- a/packages/dam_archive/tests/test_rar.py
+++ b/packages/dam_archive/tests/test_rar.py
@@ -5,6 +5,8 @@ import pytest
 
 from dam_archive.main import open_archive
 
+NUM_FILES_IN_DUMMY_RAR = 2
+
 
 @pytest.fixture
 def dummy_rar_file(tmp_path: Path) -> Path:
@@ -85,7 +87,7 @@ async def test_iter_files_rar_archive(dummy_rar_file: Path) -> None:
     assert archive is not None
 
     files = list(archive.iter_files())
-    assert len(files) == 2
+    assert len(files) == NUM_FILES_IN_DUMMY_RAR
     for member_info, f in files:
         with f:
             assert f.read()

--- a/packages/domarkx/src/domarkx/action/exec_doc.py
+++ b/packages/domarkx/src/domarkx/action/exec_doc.py
@@ -15,10 +15,10 @@ from domarkx.macro_expander import DocExpander
 from domarkx.ui.console import PROMPT_TOOLKIT_IS_MULTILINE_CONDITION
 
 
-async def aexec_doc(
+async def aexec_doc(  # noqa: PLR0912, PLR0915
     doc: pathlib.Path,
     handle_one_toolcall: bool = False,
-    allow_user_message_in_FunctionExecution: bool = True,
+    allow_user_message_in_function_execution: bool = True,
     overwrite: bool = False,
 ) -> None:
     # Read the content from the document
@@ -53,10 +53,10 @@ async def aexec_doc(
             if match:
                 # Timestamp found.
                 # Try to create a new filename with 'A' appended.
-                new_stem_with_A = f"{doc.stem}A"
-                path_with_A = doc.with_name(f"{new_stem_with_A}.md")
+                new_stem_with_a = f"{doc.stem}A"
+                path_with_a = doc.with_name(f"{new_stem_with_a}.md")
 
-                if path_with_A.exists():
+                if path_with_a.exists():
                     # File with 'A' exists, so we create a new timestamped file.
                     # We need to find the base name by stripping the found suffix.
                     base_name = doc.stem[: match.start()]
@@ -65,7 +65,7 @@ async def aexec_doc(
                     doc_to_exec = doc.with_name(new_filename)
                 else:
                     # File with 'A' does not exist, so we use it.
-                    doc_to_exec = path_with_A
+                    doc_to_exec = path_with_a
             else:
                 # No timestamp found, add one.
                 now = datetime.now().strftime(timestamp_format)
@@ -82,7 +82,7 @@ async def aexec_doc(
         task_msg: Optional[str] = None
         latest_msg = session.messages[-1] if len(session.messages) > 0 else None
         if (
-            not allow_user_message_in_FunctionExecution
+            not allow_user_message_in_function_execution
             and latest_msg
             and isinstance(latest_msg.get("content", ""), list)
         ):
@@ -98,9 +98,13 @@ async def aexec_doc(
                 if PROMPT_TOOLKIT_IS_MULTILINE_CONDITION()
                 else None,
             )
-            if latest_msg and latest_msg.get("type", "") in ["FunctionExecutionResultMessage"]:
-                if task_msg is not None and len(task_msg.strip()) == 0:
-                    task_msg = None
+            if (
+                latest_msg
+                and latest_msg.get("type", "") in ["FunctionExecutionResultMessage"]
+                and task_msg is not None
+                and not task_msg.strip()
+            ):
+                task_msg = None
 
         await domarkx.ui.console.Console(
             session.agent.run_stream(task=task_msg), output_stats=True, exit_after_one_toolcall=handle_one_toolcall
@@ -132,5 +136,5 @@ def exec_doc(
     asyncio.run(aexec_doc(doc, handle_one_toolcall, overwrite=overwrite))
 
 
-def register(main_app: typer.Typer, settings: dict[str, Any]) -> None:
+def register(main_app: typer.Typer, _: dict[str, Any]) -> None:
     main_app.command()(exec_doc)

--- a/packages/domarkx/src/domarkx/action/init.py
+++ b/packages/domarkx/src/domarkx/action/init.py
@@ -31,7 +31,7 @@ def init_project(
         os.makedirs(project_path)
 
     # Initialize Git repository
-    subprocess.run(["git", "init"], cwd=project_path)
+    subprocess.run(["git", "init"], check=False, cwd=project_path)
 
     # Add template handling
     if template_path:

--- a/packages/domarkx/src/domarkx/macro_expander.py
+++ b/packages/domarkx/src/domarkx/macro_expander.py
@@ -59,9 +59,8 @@ class MacroExpander:
 
         if include_path.exists():
             return include_path.read_text()
-        else:
-            # If the path does not exist, return the original macro text to avoid breaking the content.
-            return ""
+        # If the path does not exist, return the original macro text to avoid breaking the content.
+        return ""
 
     def _set_macro(self, macro: Macro, content: str) -> str:
         """Handles the @set macro."""

--- a/packages/domarkx/src/domarkx/tools/doc_admin.py
+++ b/packages/domarkx/src/domarkx/tools/doc_admin.py
@@ -34,11 +34,11 @@ def rename_session(old_name: str, new_name: str, project_path: str | None = None
     os.rename(old_path, new_path)
 
     # Add to git
-    subprocess.run(["git", "add", new_path], cwd=project_path)
-    subprocess.run(["git", "rm", old_path], cwd=project_path)
+    subprocess.run(["git", "add", new_path], check=False, cwd=project_path)
+    subprocess.run(["git", "rm", old_path], check=False, cwd=project_path)
     subprocess.run(
         ["git", "commit", "-m", f"Rename session {old_name} to {new_name}"],
-        cwd=project_path,
+        check=False, cwd=project_path,
     )
 
     return f"Session '{old_name}' renamed to '{new_name}'."
@@ -76,10 +76,10 @@ def update_session_metadata(session_name: str, metadata: dict[str, Any], project
         f.write(f"\n\n<!-- METADATA: {metadata} -->")
 
     # Add to git
-    subprocess.run(["git", "add", session_path], cwd=project_path)
+    subprocess.run(["git", "add", session_path], check=False, cwd=project_path)
     subprocess.run(
         ["git", "commit", "-m", f"Update metadata for session {session_name}"],
-        cwd=project_path,
+        check=False, cwd=project_path,
     )
 
     return f"Metadata updated for session '{session_name}'."

--- a/packages/domarkx/src/domarkx/tools/portable_tools/file_operations/read_file.py
+++ b/packages/domarkx/src/domarkx/tools/portable_tools/file_operations/read_file.py
@@ -103,7 +103,7 @@ def tool_read_file(
     if isinstance(path, list):
         logging.info(f"Path argument is a list, will process {len(path)} files.")
         return _read_multiple_files(path)
-    elif isinstance(path, str):
+    if isinstance(path, str):
         if glob.has_magic(path):
             logging.info(f"Path '{path}' contains wildcards, will process multiple files.")
             use_recursive = "**" in path
@@ -117,9 +117,7 @@ def tool_read_file(
                 logging.warning(warning_msg)
                 return warning_msg
             return _read_multiple_files(matching_files)
-        else:
-            return _read_single_file(path, start_line, end_line)
-    else:
-        error_msg = f"Argument 'path' must be a string or list of strings, but received {type(path).__name__}."
-        logging.error(error_msg)
-        raise TypeError(error_msg)
+        return _read_single_file(path, start_line, end_line)
+    error_msg = f"Argument 'path' must be a string or list of strings, but received {type(path).__name__}."
+    logging.error(error_msg)
+    raise TypeError(error_msg)

--- a/packages/domarkx/src/domarkx/tools/session_management.py
+++ b/packages/domarkx/src/domarkx/tools/session_management.py
@@ -51,10 +51,10 @@ def create_session(template_name: str, session_name: str, parameters: dict[str, 
         f.write(expanded_content)
 
     # Add to git
-    subprocess.run(["git", "add", session_path], cwd=settings.project_path)
+    subprocess.run(["git", "add", session_path], check=False, cwd=settings.project_path)
     subprocess.run(
         ["git", "commit", "-m", f"Create session {session_name}"],
-        cwd=settings.project_path,
+        check=False, cwd=settings.project_path,
     )
 
     return f"Session '{session_name}' created from template '{template_name}'."
@@ -90,10 +90,10 @@ def send_message(session_name: str, message: str) -> str:
         f.write(f"\n\n{message}")
 
     # Add to git
-    subprocess.run(["git", "add", session_path], cwd=settings.project_path)
+    subprocess.run(["git", "add", session_path], check=False, cwd=settings.project_path)
     subprocess.run(
         ["git", "commit", "-m", f"Send message to session {session_name}"],
-        cwd=settings.project_path,
+        check=False, cwd=settings.project_path,
     )
 
     return f"Message sent to session '{session_name}'."
@@ -184,11 +184,11 @@ def archive_session(session_name: str, topic: str) -> str:
     os.rename(session_path, new_session_path)
 
     # Add to git
-    subprocess.run(["git", "add", new_session_path], cwd=settings.project_path)
-    subprocess.run(["git", "rm", session_path], cwd=settings.project_path)
+    subprocess.run(["git", "add", new_session_path], check=False, cwd=settings.project_path)
+    subprocess.run(["git", "rm", session_path], check=False, cwd=settings.project_path)
     subprocess.run(
         ["git", "commit", "-m", f"Archive session {session_name} to {topic}"],
-        cwd=settings.project_path,
+        check=False, cwd=settings.project_path,
     )
 
     return f"Session '{session_name}' archived to '{new_session_path}'."

--- a/packages/domarkx/src/domarkx/ui/console.py
+++ b/packages/domarkx/src/domarkx/ui/console.py
@@ -65,11 +65,10 @@ class UserInputManager:
                 # Cast to AsyncInputFunc for proper typing
                 async_func = cast(AsyncInputFunc, self.callback)
                 return await async_func(prompt, cancellation_token)
-            else:
-                # Cast to SyncInputFunc for proper typing
-                sync_func = cast(SyncInputFunc, self.callback)
-                loop = asyncio.get_event_loop()
-                return await loop.run_in_executor(None, sync_func, prompt)
+            # Cast to SyncInputFunc for proper typing
+            sync_func = cast(SyncInputFunc, self.callback)
+            loop = asyncio.get_event_loop()
+            return await loop.run_in_executor(None, sync_func, prompt)
 
         return user_input_func_wrapper
 

--- a/packages/domarkx/tests/test_code_execution.py
+++ b/packages/domarkx/tests/test_code_execution.py
@@ -22,9 +22,8 @@ def test_execute_code_block_failure_with_source() -> None:
     """
     code = "a = 1\nb = a / 0"
     f = io.StringIO()
-    with redirect_stderr(f):
-        with pytest.raises(ZeroDivisionError):
-            execute_code_block(code)
+    with redirect_stderr(f), pytest.raises(ZeroDivisionError):
+        execute_code_block(code)
 
     s = f.getvalue()
     assert "b = a / 0" in s

--- a/packages/domarkx/tests/test_function_execution.py
+++ b/packages/domarkx/tests/test_function_execution.py
@@ -28,4 +28,4 @@ async def test_function_execution_in_temp_dir(filepath: str, tmp_path: pathlib.P
     temp_doc_path = tmp_path / os.path.basename(filepath)
     shutil.copy(filepath, temp_doc_path)
     doc_path = pathlib.Path(temp_doc_path)
-    await aexec_doc(doc_path, handle_one_toolcall=True, allow_user_message_in_FunctionExecution=False)
+    await aexec_doc(doc_path, handle_one_toolcall=True, allow_user_message_in_function_execution=False)


### PR DESCRIPTION
…ff across the `dam_archive` and `domarkx` packages.

Key changes include:
- Refactored complex functions in `dam_archive/systems/ingestion.py` into smaller, more manageable helpers to improve readability and reduce complexity.
- Replaced banned `unittest.mock` imports with `pytest-mock` equivalents in tests.
- Fixed numerous code style issues, such as using `contextlib.suppress`, `pathlib.Path` methods, and lazy logging.
- Corrected variable and argument names to follow Python's `snake_case` convention.
- Addressed test failures that arose from the refactoring.